### PR TITLE
Allow imageruler to be used as a command

### DIFF
--- a/imageruler/cli.py
+++ b/imageruler/cli.py
@@ -1,0 +1,24 @@
+import numpy as np
+import argparse
+import imageruler
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=
+        "A python package for estimating minimum lengthscales in binary images"
+    )
+    parser.add_argument(
+        'file',
+        type=str,
+        help="Path of the text file containing the image array.")
+    args = parser.parse_args()
+
+    solid_mls, void_mls = imageruler.minimum_length_solid_void(
+        np.loadtxt(args.file))
+    print("Minimum lengthscales of solid and void regions: ", solid_mls,
+          void_mls)
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/examples.ipynb
+++ b/notebooks/examples.ipynb
@@ -9,9 +9,10 @@
     "import numpy as np\n",
     "#import sys # Uncomment this and the next line if imageruler is cloned rather than installed.\n",
     "#sys.path.append(\"../imageruler\")\n",
-    "import imageruler # import imageruler\n",
+    "import imageruler\n",
     "from matplotlib import pyplot as plt\n",
-    "from regular_shapes import disc, rounded_square, stripe # import three functions from regular_shapes.py to generate regular shapes"
+    "# In the next line, remove \"imageruler.\" if imageruler is cloned rather than installed.\n",
+    "from imageruler.regular_shapes import disc, rounded_square, stripe # Import functions that generate regular shapes."
    ]
   },
   {
@@ -445,6 +446,13 @@
     "# disregard the short void and solid regions at both ends\n",
     "solid_mls, void_mls = imageruler.minimum_length_solid_void(image, phys_size, margin_size=(void_mls,solid_mls))\n",
     "print(\"Estimated minimum length scales with some end regions disregarded: \", solid_mls, \"(solid), \", void_mls, \"(void)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This package can also be used as a command in the Linux command line, with the function \"minimum_length_solid_void()\" being invoked. The syntax is \"imageruler file\", where \"file\" is a string of the path of the text file that contains the array of the input image. All other arguments of the function take default options."
    ]
   }
  ],

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ def read(rel_path):
     with codecs.open(os.path.join(here, rel_path), 'r') as fp:
         return fp.read()
 
+
 def get_version(rel_path):
     for line in read(rel_path).splitlines():
         if line.startswith('__version__'):
@@ -33,4 +34,6 @@ setuptools.setup(
     url='https://github.com/NanoComp/imageruler',
     packages=setuptools.find_packages(),
     python_requires='>=3',
-)
+    entry_points={"console_scripts": [
+        "imageruler = imageruler.cli:main",
+    ]})


### PR DESCRIPTION
This PR allows `imageruler` to be used as a command in the Linux command line. The usage is described at the end of `examples.ipynb`.