### PR TITLE
Cleanup imageruler codebase

### DIFF
--- a/imageruler/__init__.py
+++ b/imageruler/__init__.py
@@ -5,6 +5,7 @@ __version__ = '1.0'
 import imageruler.imageruler
 import imageruler.regular_shapes
 from .imageruler import (
+    PaddingMode,
     binary_close,
     binary_dilate,
     binary_erode,

--- a/imageruler/__init__.py
+++ b/imageruler/__init__.py
@@ -1,6 +1,19 @@
+"""Imageruler."""
 
 __version__ = '1.0'
 
 import imageruler.imageruler
-from .imageruler import minimum_length_solid, minimum_length_void, minimum_length_solid_void, minimum_length, length_violation_solid, length_violation_void, length_violation, binary_open, binary_close, binary_erode, binary_dilate
 import imageruler.regular_shapes
+from .imageruler import (
+    binary_close,
+    binary_dilate,
+    binary_erode,
+    binary_open,
+    length_violation,
+    length_violation_solid,
+    length_violation_void,
+    minimum_length,
+    minimum_length_solid,
+    minimum_length_solid_void,
+    minimum_length_void,
+)

--- a/imageruler/cli.py
+++ b/imageruler/cli.py
@@ -1,24 +1,27 @@
-import numpy as np
+"""Command line interface for imageruler."""
+
 import argparse
 import imageruler
+import numpy as np
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description=
-        "A python package for estimating minimum lengthscales in binary images"
-    )
-    parser.add_argument(
-        'file',
-        type=str,
-        help="Path of the text file containing the image array.")
-    args = parser.parse_args()
+  parser = argparse.ArgumentParser(
+      description=(
+          "A python package for estimating minimum lengthscales in binary"
+          " images"
+      )
+  )
+  parser.add_argument(
+      "file", type=str, help="Path of the text file containing the image array."
+  )
+  args = parser.parse_args()
 
-    solid_mls, void_mls = imageruler.minimum_length_solid_void(
-        np.loadtxt(args.file))
-    print("Minimum lengthscales of solid and void regions: ", solid_mls,
-          void_mls)
+  solid_mls, void_mls = imageruler.minimum_length_solid_void(
+      np.loadtxt(args.file)
+  )
+  print("Minimum lengthscales of solid and void regions: ", solid_mls, void_mls)
 
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/imageruler/imageruler.py
+++ b/imageruler/imageruler.py
@@ -1,842 +1,892 @@
-from typing import Tuple, Optional
-import warnings
+"""Imageruler for measuring minimum lengthscales in binary images."""
 
+import enum
+from typing import Optional, Tuple
+import warnings
 import cv2 as cv
 import numpy as np
 
-warnings.simplefilter("always")
+warnings.simplefilter('always')
 
-threshold = 0.5  # threshold for binarization
+# Threshold used for binarization.
+_BINARIZATION_THRESHOLD = 0.5
 
-
-def minimum_length_solid(arr: np.ndarray,
-                         phys_size: Optional[Tuple[float, ...]] = None,
-                         periodic_axes: Optional[Tuple[float, ...]] = None,
-                         margin_size: Optional[Tuple[Tuple[float, float],
-                                                     ...]] = None,
-                         pad_mode: str = 'solid',
-                         warn_cusp: bool = False) -> float:
-    """Computes the minimum length scale of the solid regions of an image.
-
-    Args:
-        arr: The image as a 1d or 2d array.
-        phys_size: The physical dimensions of the image. Default is None.
-        periodic_axes: The axes which are periodic. x is 0 and y is 1.
-            Default is None.
-        margin_size: The physical dimensions of the image margins. If specified,
-            this subregion is excluded from the result. Default is None.
-        pad_mode: A string that represents the padding mode. One of
-            'solid', 'void', or 'edge'. Default is 'solid'.
-        warn_cusp: Whether to warn about the presence of sharp corners or
-            cusps detected in the image. Default is False (no warning).
-
-    Returns:
-        The minimum length scale of the solid regions. The units are the same
-        as `phys_size`. If `phys_size` is None, the units are in number of
-        pixels.
-    """
-
-    arr, pixel_size, short_pixel_side, short_entire_side = _ruler_initialize(
-        arr, phys_size, periodic_axes, warn_cusp)
-
-    # If all of the elements in the array are the same,
-    # the shorter length of the image is considered to
-    # be its minimum length scale.
-    if len(np.unique(arr)) == 1:
-        return short_entire_side
-
-    if arr.ndim == 1:
-        if margin_size is not None:
-            arr = _trim(arr, margin_size, pixel_size)
-        solid_min_length, _ = _minimum_length_1d(arr)
-        return solid_min_length * short_pixel_side
-
-    def _interior_pixel_number(diameter: float, arr: np.ndarray) -> bool:
-        """Determines whether an image violates a given length scale.
-
-        The violation is based on whether the difference between the image and
-        its morphological opening is nonzero in the interior of the solid
-        regions.
-
-        Args:
-            diameter: The diameter of the kernel (or "probe").
-            arr: The image as a 2d array.
-
-        Returns:
-            True if a violation is detected, False otherwise.
-        """
-        return _length_violation_solid(arr, diameter, pixel_size, margin_size,
-                                       pad_mode).any()
-
-    min_len, _ = _search([short_pixel_side, short_entire_side],
-                         min(pixel_size) / 2,
-                         lambda d: _interior_pixel_number(d, arr))
-
-    return min_len
+PhysicalSize = Tuple[float, ...]
+PixelSize = Tuple[float, ...]
+MarginSize = Tuple[Tuple[float, float], ...]
+PeriodicAxes = Tuple[int, ...]
 
 
-def minimum_length_void(arr: np.ndarray,
-                        phys_size: Optional[Tuple[float, ...]] = None,
-                        periodic_axes: Optional[Tuple[float, ...]] = None,
-                        margin_size: Optional[Tuple[Tuple[float, float],
-                                                    ...]] = None,
-                        pad_mode: str = 'void',
-                        warn_cusp: bool = False) -> float:
-    """Computes the minimum length scale of the void regions in an image.
-
-    Args:
-        arr: The image as a 1d or 2d array.
-        phys_size: The physical dimensions of the image. Default is None.
-        periodic_axes: The axes which are periodic. x is 0 and y is 1.
-            Default is None.
-        margin_size: The physical dimensions of the image margins. If specified,
-            this subregion is excluded from the result. Default is None.
-        pad_mode: A string that represents the padding mode. One of
-            'solid', 'void', or 'edge'. Default is 'solid'.
-        warn_cusp: Whether to warn about the presence of sharp corners or
-            cusps detected in the image. Default is False (no warning).
-
-    Returns:
-        The minimum length scale of the void regions. The units are the same
-        as `phys_size`. If `phys_size` is None, the units are in number of
-        pixels.
-    """
-    arr, pixel_size, short_pixel_side, short_entire_side = _ruler_initialize(
-        arr, phys_size)
-    if pad_mode == 'solid': pad_mode = 'void'
-    elif pad_mode == 'void': pad_mode = 'solid'
-    else: pad_mode == 'edge'
-
-    return minimum_length_solid(~arr, phys_size, periodic_axes, margin_size,
-                                pad_mode, warn_cusp)
+@enum.unique
+class PaddingMode(enum.Enum):
+  EDGE = 'edge'
+  SOLID = 'solid'
+  VOID = 'void'
 
 
-def minimum_length_solid_void(arr: np.ndarray,
-                              phys_size: Optional[Tuple[float, ...]] = None,
-                              periodic_axes: Optional[Tuple[float,
-                                                            ...]] = None,
-                              margin_size: Optional[Tuple[Tuple[float, float],
-                                                          ...]] = None,
-                              pad_mode: Tuple[str, str] = ('solid', 'void'),
-                              warn_cusp: bool = False) -> Tuple[float, float]:
-    """Computes the minimum length scale of an image.
+def minimum_length_solid(
+    array: np.ndarray,
+    phys_size: Optional[PhysicalSize] = None,
+    periodic_axes: Optional[PeriodicAxes] = None,
+    margin_size: Optional[MarginSize] = None,
+    pad_mode: PaddingMode = PaddingMode.SOLID,
+    warn_cusp: bool = False,
+) -> float:
+  """Computes the minimum length scale of the solid regions of an image.
 
-    Args:
-        arr: The image as a 1d or 2d array.
-        phys_size: The physical dimensions of the image. Default is None.
-        periodic_axes: The axes which are periodic. x is 0 and y is 1.
-            Default is None.
-        margin_size: The physical dimensions of the image margins. If specified,
-            this subregion is excluded from the result. Default is None.
-        pad_mode: A string that represents the padding mode, which can be
-            'solid', 'void', or 'edge'. Default is 'solid'.
-        warn_cusp: A boolean value that specifies whether to warn about sharp
-            corners or cusps. If True, a warning will be given when arr
-            is likely to contain sharp corners or cusps. Default is False
-            (no warning).
+  Args:
+    array: The image as a 1d or 2d array.
+    phys_size: The physical dimensions of the image. Default is None.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
+      None.
+    margin_size: The physical dimensions of the image margins. If specified,
+      this subregion is excluded from the result. Default is None.
+    pad_mode: The padding mode, defaults to solid.
+    warn_cusp: Whether to warn about the presence of sharp corners or cusps
+      detected in the image. Default is False (no warning).
 
-    Returns:
-        The minimum length scale of the solid and void regions in the same unit
-        as `phys_size`. If `phys_size` is None, the units are in number of
-        pixels.
-    """
-    return minimum_length_solid(arr, phys_size, periodic_axes, margin_size,
-                                pad_mode[0], warn_cusp), minimum_length_void(
-                                    arr, phys_size, periodic_axes, margin_size,
-                                    pad_mode[1])
+  Returns:
+    The minimum length scale of the solid regions. The units are the same
+    as `phys_size`. If `phys_size` is None, the units are in number of
+    pixels.
+  """
 
+  array, pixel_size, short_pixel_side, short_entire_side = _ruler_initialize(
+      array, phys_size, periodic_axes, warn_cusp
+  )
 
-def minimum_length(arr: np.ndarray,
-                   phys_size: Optional[Tuple[float, ...]] = None,
-                   periodic_axes: Optional[Tuple[float, ...]] = None,
-                   margin_size: Optional[Tuple[Tuple[float, float],
-                                               ...]] = None,
-                   pad_mode: Tuple[str, str] = ('solid', 'void'),
-                   warn_cusp: bool = False) -> float:
-    """Computes the minimum length scale of an image.
+  # If all of the elements in the array are the same,
+  # the shorter length of the image is considered to
+  # be its minimum length scale.
+  if len(np.unique(array)) == 1:
+    return short_entire_side
 
-    This is the smaller of the minimum length scale of the solid and void
-    regions. For a 2d image, this is computed using the difference between
-    morphological opening and closing. For a 1d image, this is computed using
-    a brute-force search.
-
-    Args:
-        arr: The image as a 1d or 2d array.
-        phys_size: The physical dimensions of the image. Default is None.
-        periodic_axes: The axes which are periodic. x is 0 and y is 1.
-            Default is None.
-        margin_size: The physical dimensions of the image margins. If specified,
-            this subregion is excluded from the result. Default is None.
-        pad_mode: A string that represents the padding mode, which can be
-            'solid', 'void', or 'edge'. Default is 'solid'.
-        warn_cusp: A boolean value that specifies whether to warn about sharp
-            corners or cusps. If True, a warning will be given when arr
-            is likely to contain sharp corners or cusps. Default is no
-            warning (False).
-
-    Returns:
-        The minimum length scale of the solid and void regions in the same unit
-        as `phys_size`. If `phys_size` is None, the units are in number of
-        pixels.
-    """
-    arr, pixel_size, short_pixel_side, short_entire_side = _ruler_initialize(
-        arr, phys_size, periodic_axes, warn_cusp)
-
-    # If all of the elements in the array are the same,
-    # the shorter length of the image is considered to
-    # be its minimum length scale.
-    if len(np.unique(arr)) == 1:
-        return short_entire_side
-
-    if arr.ndim == 1:
-        if margin_size is not None:
-            arr = _trim(arr, margin_size, pixel_size)
-        solid_min_length, void_min_length = _minimum_length_1d(arr)
-        return min(solid_min_length, void_min_length) * short_pixel_side
-
-    if isinstance(pad_mode, str): pad_mode = (pad_mode, pad_mode)
-
-    def _interior_pixel_number(diameter: float, arr: np.ndarray) -> bool:
-        """Determines whether an image violates a given length scale.
-
-        The violation is based on whether the difference between the image and
-        its morphological opening is nonzero in the interior of the solid
-        regions.
-
-        Args:
-            diameter: The diameter of the kernel (or "probe").
-            arr: The image as a 2d array.
-
-        Returns:
-            True if a violation is detected, False otherwise.
-        """
-        return _length_violation(arr, diameter, pixel_size, margin_size,
-                                 pad_mode).any()
-
-    min_len, _ = _search([short_pixel_side, short_entire_side],
-                         min(pixel_size) / 2,
-                         lambda d: _interior_pixel_number(d, arr))
-
-    return min_len
-
-
-def _length_violation_solid(arr: np.ndarray,
-                            diameter: float,
-                            pixel_size: Tuple[float, float],
-                            margin_size: Optional[Tuple[Tuple[float, float],
-                                                        ...]] = None,
-                            pad_mode: str = 'solid') -> np.ndarray:
-    """Identifies the solid subregions which contain length scale violations.
-
-    Args:
-        arr: The image as a 2d array.
-        diameter: The diameter of the kernel (or "probe").
-        phys_size: The physical dimensions of the image. Default is None.
-        margin_size: The physical dimensions of the image margins. If specified,
-            this subregion is excluded from the result. Default is None.
-        pad_mode: A string that represents the padding mode, which can be
-            'solid', 'void', or 'edge'. Default is 'solid'.
-
-    Returns:
-        A 2d array of the violations. The array dimensions are the same as the
-        original image.
-    """
-
-    open_diff = binary_open(arr, diameter, pixel_size, pad_mode) ^ arr
-    interior_diff = open_diff & _get_interior(arr, "in", pad_mode)
+  if array.ndim == 1:
     if margin_size is not None:
-        interior_diff = _trim(interior_diff, margin_size, pixel_size)
+      array = _trim(array, margin_size, pixel_size)
+    solid_min_length, _ = _minimum_length_1d(array)
+    return solid_min_length * short_pixel_side
 
-    return interior_diff
+  def _interior_pixel_number(diameter: float, array: np.ndarray) -> bool:
+    """Determines whether an image violates a given length scale."""
+    return _length_violation_solid(
+        array, diameter, pixel_size, margin_size, pad_mode
+    ).any()
+
+  min_len, _ = _search(
+      [short_pixel_side, short_entire_side],
+      min(pixel_size) / 2,
+      lambda d: _interior_pixel_number(d, array),
+  )
+
+  return min_len
+
+
+def minimum_length_void(
+    array: np.ndarray,
+    phys_size: Optional[PhysicalSize] = None,
+    periodic_axes: Optional[PeriodicAxes] = None,
+    margin_size: Optional[MarginSize] = None,
+    pad_mode: PaddingMode = PaddingMode.VOID,
+    warn_cusp: bool = False,
+) -> float:
+  """Computes the minimum length scale of the void regions in an image.
+
+  Args:
+    array: The image as a 1d or 2d array.
+    phys_size: The physical dimensions of the image. Default is None.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
+      None.
+    margin_size: The physical dimensions of the image margins. If specified,
+      this subregion is excluded from the result. Default is None.
+    pad_mode: The padding mode, defaults to void.
+    warn_cusp: Whether to warn about the presence of sharp corners or cusps
+      detected in the image. Default is False (no warning).
+
+  Returns:
+    The minimum length scale of the void regions. The units are the same
+    as `phys_size`. If `phys_size` is None, the units are in number of
+    pixels.
+  """
+  array, _, _, _ = _ruler_initialize(array, phys_size)
+  if pad_mode is PaddingMode.SOLID:
+    pad_mode = PaddingMode.VOID
+  elif pad_mode is PaddingMode.VOID:
+    pad_mode = PaddingMode.SOLID
+  else:
+    pad_mode = PaddingMode.EDGE
+
+  return minimum_length_solid(
+      ~array, phys_size, periodic_axes, margin_size, pad_mode, warn_cusp
+  )
+
+
+def minimum_length_solid_void(
+    array: np.ndarray,
+    phys_size: Optional[PhysicalSize] = None,
+    periodic_axes: Optional[PeriodicAxes] = None,
+    margin_size: Optional[MarginSize] = None,
+    pad_mode: Tuple[PaddingMode, PaddingMode] = (
+        PaddingMode.SOLID,
+        PaddingMode.VOID,
+    ),
+    warn_cusp: bool = False,
+) -> Tuple[float, float]:
+  """Computes the minimum length scale of an image.
+
+  Args:
+    array: The image as a 1d or 2d array.
+    phys_size: The physical dimensions of the image. Default is None.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
+      None.
+    margin_size: The physical dimensions of the image margins. If specified,
+      this subregion is excluded from the result. Default is None.
+    pad_mode: The padding mode to apply to the solid and void phases.
+    warn_cusp: A boolean value that specifies whether to warn about sharp
+      corners or cusps. If True, a warning will be given when arr is likely to
+      contain sharp corners or cusps. Default is False (no warning).
+
+  Returns:
+    The minimum length scale of the solid and void regions in the same unit
+    as `phys_size`. If `phys_size` is None, the units are in number of
+    pixels.
+  """
+  return minimum_length_solid(
+      array, phys_size, periodic_axes, margin_size, pad_mode[0], warn_cusp
+  ), minimum_length_void(
+      array, phys_size, periodic_axes, margin_size, pad_mode[1]
+  )
+
+
+def minimum_length(
+    array: np.ndarray,
+    phys_size: Optional[PhysicalSize] = None,
+    periodic_axes: Optional[PeriodicAxes] = None,
+    margin_size: Optional[MarginSize] = None,
+    pad_mode: PaddingMode | Tuple[PaddingMode, PaddingMode] = (
+        PaddingMode.SOLID,
+        PaddingMode.VOID,
+    ),
+    warn_cusp: bool = False,
+) -> float:
+  """Computes the minimum length scale of an image.
+
+  This is the smaller of the minimum length scale of the solid and void
+  regions. For a 2d image, this is computed using the difference between
+  morphological opening and closing. For a 1d image, this is computed using
+  a brute-force search.
+
+  Args:
+    array: The image as a 1d or 2d array.
+    phys_size: The physical dimensions of the image. Default is None.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
+      None.
+    margin_size: The physical dimensions of the image margins. If specified,
+      this subregion is excluded from the result. Default is None.
+    pad_mode: The padding mode to apply to the solid and void phases.
+    warn_cusp: A boolean value that specifies whether to warn about sharp
+      corners or cusps. If True, a warning will be given when arr is likely to
+      contain sharp corners or cusps. Default is no warning (False).
+
+  Returns:
+    The minimum length scale of the solid and void regions in the same unit
+    as `phys_size`. If `phys_size` is None, the units are in number of
+    pixels.
+  """
+  array, pixel_size, short_pixel_side, short_entire_side = _ruler_initialize(
+      array, phys_size, periodic_axes, warn_cusp
+  )
+
+  # If all of the elements in the array are the same,
+  # the shorter length of the image is considered to
+  # be its minimum length scale.
+  if len(np.unique(array)) == 1:
+    return short_entire_side
+
+  if array.ndim == 1:
+    if margin_size is not None:
+      array = _trim(array, margin_size, pixel_size)
+    solid_min_length, void_min_length = _minimum_length_1d(array)
+    return min(solid_min_length, void_min_length) * short_pixel_side
+
+  if isinstance(pad_mode, PaddingMode):
+    pad_mode = (pad_mode, pad_mode)
+
+  def _interior_pixel_number(diameter: float, arr: np.ndarray) -> bool:
+    """Determines whether an image violates a given length scale."""
+    return _length_violation(
+        arr, diameter, pixel_size, margin_size, pad_mode
+    ).any()
+
+  min_len, _ = _search(
+      [short_pixel_side, short_entire_side],
+      min(pixel_size) / 2,
+      lambda d: _interior_pixel_number(d, array),
+  )
+
+  return min_len
+
+
+def _length_violation_solid(
+    array: np.ndarray,
+    diameter: float,
+    pixel_size: PixelSize,
+    margin_size: Optional[Tuple[Tuple[float, float], ...]] = None,
+    pad_mode: PaddingMode = PaddingMode.SOLID,
+) -> np.ndarray:
+  """Identifies the solid subregions which contain length scale violations."""
+
+  open_diff = binary_open(array, diameter, pixel_size, pad_mode) ^ array
+  interior_diff = open_diff & _get_interior(array, 'in', pad_mode)
+  if margin_size is not None:
+    interior_diff = _trim(interior_diff, margin_size, pixel_size)
+
+  return interior_diff
 
 
 def _length_violation(
-    arr: np.ndarray,
+    array: np.ndarray,
     diameter: float,
-    pixel_size: Tuple[float, float],
-    margin_size: Optional[Tuple[Tuple[float, float], ...]] = None,
-    pad_mode: Tuple[str, str] = ('solid', 'void')
+    pixel_size: PixelSize,
+    margin_size: Optional[MarginSize] = None,
+    pad_mode: Tuple[PaddingMode, PaddingMode] = (
+        PaddingMode.SOLID,
+        PaddingMode.VOID,
+    ),
 ) -> np.ndarray:
-    """Identifies the subregions which contain length scale violations.
+  """Identifies the subregions which contain length scale violations."""
 
-    Args:
-        arr: The image as a 2d array.
-        diameter: The diameter of the kernel (or "probe").
-        phys_size: The physical dimensions of the image. Default is None.
-        margin_size: The physical dimensions of the image margins. If specified,
-            this subregion is excluded from the result. Default is None.
-        pad_mode: A string that represents the padding mode, which can be
-            'solid', 'void', or 'edge'. Default is 'solid'.
+  close_open_diff = binary_open(
+      array, diameter, pixel_size, pad_mode[0]
+  ) ^ binary_close(array, diameter, pixel_size, pad_mode[1])
+  interior_diff = close_open_diff & _get_interior(array, 'both', pad_mode)
+  if margin_size is not None:
+    interior_diff = _trim(interior_diff, margin_size, pixel_size)
 
-    Returns:
-        A 2d array of the violations. The array dimensions are the same as the
-        original image.
-    """
-
-    close_open_diff = binary_open(arr, diameter, pixel_size,
-                                  pad_mode[0]) ^ binary_close(
-                                      arr, diameter, pixel_size, pad_mode[1])
-    interior_diff = close_open_diff & _get_interior(arr, "both", pad_mode)
-    if margin_size is not None:
-        interior_diff = _trim(interior_diff, margin_size, pixel_size)
-
-    return interior_diff
+  return interior_diff
 
 
-def length_violation_solid(arr: np.ndarray,
-                           diameter: float,
-                           phys_size: Optional[Tuple[float, ...]] = None,
-                           periodic_axes: Optional[Tuple[float, ...]] = None,
-                           margin_size: Optional[Tuple[Tuple[float, float],
-                                                       ...]] = None,
-                           pad_mode: str = 'solid') -> np.ndarray:
-    """Identifies the solid subregions which contain length scale violations.
+def length_violation_solid(
+    array: np.ndarray,
+    diameter: float,
+    phys_size: Optional[PhysicalSize] = None,
+    periodic_axes: Optional[PeriodicAxes] = None,
+    margin_size: Optional[MarginSize] = None,
+    pad_mode: PaddingMode = PaddingMode.SOLID,
+) -> np.ndarray:
+  """Identifies the solid subregions which contain length scale violations.
 
-    Args:
-        arr: The image as a 2d array.
-        diameter: The diameter of the kernel (or "probe").
-        phys_size: The physical dimensions of the image. Default is None.
-        periodic_axes: The axes which are periodic. x is 0 and y is 1.
-            Default is None.
-        margin_size: The physical dimensions of the image margins. If specified,
-            this subregion is excluded from the result. Default is None.
-        pad_mode: A string that represents the padding mode, which can be
-            'solid', 'void', or 'edge'. Default is 'solid'.
+  Args:
+    array: The image as a 2d array.
+    diameter: The diameter of the kernel (or "probe").
+    phys_size: The physical dimensions of the image. Default is None.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
+      None.
+    margin_size: The physical dimensions of the image margins. If specified,
+      this subregion is excluded from the result. Default is None.
+    pad_mode: The padding mode, defaults to solid.
 
-    Returns:
-        A 2d array of the violations. The array dimensions are the same as the
-        original image.
-    """
+  Returns:
+      A 2d array of the violations. The array dimensions are the same as the
+      original image.
+  """
 
-    arr, pixel_size, _, _ = _ruler_initialize(arr, phys_size, periodic_axes)
-    assert arr.ndim == 2
-    return _length_violation_solid(arr, diameter, pixel_size, margin_size,
-                                   pad_mode)
+  array, pixel_size, _, _ = _ruler_initialize(array, phys_size, periodic_axes)
+  assert array.ndim == 2
+  return _length_violation_solid(
+      array, diameter, pixel_size, margin_size, pad_mode
+  )
 
 
-def length_violation_void(arr: np.ndarray,
-                          diameter: float,
-                          phys_size: Optional[Tuple[float, ...]] = None,
-                          periodic_axes: Optional[Tuple[float, ...]] = None,
-                          margin_size: Optional[Tuple[Tuple[float, float],
-                                                      ...]] = None,
-                          pad_mode: str = 'void') -> np.ndarray:
-    """Identifies the void subregions which contain length scale violations.
+def length_violation_void(
+    array: np.ndarray,
+    diameter: float,
+    phys_size: Optional[PhysicalSize] = None,
+    periodic_axes: Optional[PeriodicAxes] = None,
+    margin_size: Optional[MarginSize] = None,
+    pad_mode: str = 'void',
+) -> np.ndarray:
+  """Identifies the void subregions which contain length scale violations.
 
-    Args:
-        arr: The image as a 2d array.
-        diameter: The diameter of the kernel (or "probe").
-        phys_size: The physical dimensions of the image. Default is None.
-        periodic_axes: The axes which are periodic. x is 0 and y is 1.
-            Default is None.
-        margin_size: The physical dimensions of the image margins. If specified,
-            this subregion is excluded from the result. Default is None.
-        pad_mode: A string that represents the padding mode, which can be
-            'solid', 'void', or 'edge'. Default is 'solid'.
+  Args:
+    array: The image as a 2d array.
+    diameter: The diameter of the kernel (or "probe").
+    phys_size: The physical dimensions of the image. Default is None.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
+      None.
+    margin_size: The physical dimensions of the image margins. If specified,
+      this subregion is excluded from the result. Default is None.
+    pad_mode: A string that represents the padding mode, which can be 'solid',
+      'void', or 'edge'. Default is 'solid'.
 
-    Returns:
-        A 2d array of the violations. The array dimensions are the same as the
-        original image.
-    """
+  Returns:
+      A 2d array of the violations. The array dimensions are the same as the
+      original image.
+  """
 
-    arr, pixel_size, _, _ = _ruler_initialize(arr, phys_size, periodic_axes)
-    assert arr.ndim == 2
+  array, pixel_size, _, _ = _ruler_initialize(array, phys_size, periodic_axes)
+  assert array.ndim == 2
 
-    if pad_mode == 'solid': pad_mode = 'void'
-    elif pad_mode == 'void': pad_mode = 'solid'
-    else: pad_mode == 'edge'
+  if pad_mode is PaddingMode.SOLID:
+    pad_mode = PaddingMode.VOID
+  elif pad_mode is PaddingMode.VOID:
+    pad_mode = PaddingMode.SOLID
+  else:
+    pad_mode = PaddingMode.EDGE
 
-    return _length_violation_solid(~arr, diameter, pixel_size, margin_size,
-                                   pad_mode)
+  return _length_violation_solid(
+      ~array, diameter, pixel_size, margin_size, pad_mode
+  )
 
 
 def length_violation(
-    arr: np.ndarray,
+    array: np.ndarray,
     diameter: float,
-    phys_size: Optional[Tuple[float, ...]] = None,
-    periodic_axes: Optional[Tuple[float, ...]] = None,
-    margin_size: Optional[Tuple[Tuple[float, float], ...]] = None,
-    pad_mode: Tuple[str, str] = ('solid', 'void')
+    phys_size: Optional[PhysicalSize] = None,
+    periodic_axes: Optional[PeriodicAxes] = None,
+    margin_size: Optional[MarginSize] = None,
+    pad_mode: Tuple[PaddingMode, PaddingMode] = (
+        PaddingMode.SOLID,
+        PaddingMode.VOID,
+    ),
 ) -> np.ndarray:
-    """Identifies the subregions which contain length scale violations.
+  """Identifies the subregions which contain length scale violations.
 
-    Args:
-        arr: The image as a 2d array.
-        diameter: The diameter of the kernel (or "probe").
-        phys_size: The physical dimensions of the image. Default is None.
-        periodic_axes: The axes which are periodic. x is 0 and y is 1.
-            Default is None.
-        margin_size: The physical dimensions of the image margins. If specified,
-            this subregion is excluded from the result. Default is None.
-        pad_mode: A string that represents the padding mode, which can be
-            'solid', 'void', or 'edge'. Default is 'solid'.
+  Args:
+      array: The image as a 2d array.
+      diameter: The diameter of the kernel (or "probe").
+      phys_size: The physical dimensions of the image. Default is None.
+      periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
+        None.
+      margin_size: The physical dimensions of the image margins. If specified,
+        this subregion is excluded from the result. Default is None.
+      pad_mode: The padding mode, defaults to solid.
 
-    Returns:
-        A 2d array of the violations. The array dimensions are the same as the
-        original image.
-    """
+  Returns:
+      A 2d array of the violations. The array dimensions are the same as the
+      original image.
+  """
 
-    arr, pixel_size, _, _ = _ruler_initialize(arr, phys_size, periodic_axes)
-    assert arr.ndim == 2
-    if isinstance(pad_mode, str): pad_mode = (pad_mode, pad_mode)
+  array, pixel_size, _, _ = _ruler_initialize(array, phys_size, periodic_axes)
+  assert array.ndim == 2
+  if isinstance(pad_mode, str):
+    pad_mode = (pad_mode, pad_mode)
 
-    return _length_violation(arr, diameter, pixel_size, margin_size, pad_mode)
+  return _length_violation(array, diameter, pixel_size, margin_size, pad_mode)
 
 
-def _ruler_initialize(arr, phys_size, periodic_axes=None, warn_cusp=False):
-    """
-    Convert the input array to a Boolean array without redundant dimensions and compute some basic information of the image.
+def _ruler_initialize(
+    array: np.ndarray,
+    phys_size: PhysicalSize,
+    periodic_axes: Optional[PeriodicAxes] = None,
+    warn_cusp: bool = False,
+):
+  """Initializes the ruler.
 
-    Args:
-        arr: An array that represents an image.
-        phys_size: A tuple, list, array, or number that represents the physical size of the image.
-        periodic_axes: A tuple of axes (x, y = 0, 1) treated as periodic (default is None: all axes are non-periodic).
-        warn_cusp: A boolean value that determines whether to warn about sharp corners or cusps. If True, warning will be given when the input 2d image is likely to contain sharp corners or cusps; if False, warning will not be given.
+  This function converts the input array to a boolean array without redundant
+  dimensions and computes some basic information about the image.
 
-    Returns:
-        A tuple with four elements. The first is a Boolean array obtained by squeezing and binarizing the input array, the second is an array that contains the pixel size, the third is the length of the shorter side of the pixel, and the fourth is the length of the shorter side of the image.
+  Args:
+      array: An array that represents an image.
+      phys_size: A tuple, list, array, or number that represents the physical
+        size of the image.
+      periodic_axes: A tuple of axes (x, y = 0, 1) treated as periodic (default
+        is None: all axes are non-periodic).
+      warn_cusp: A boolean value that determines whether to warn about sharp
+        corners or cusps. If True, warning will be given when the input 2d image
+        is likely to contain sharp corners or cusps; if False, warning will not
+        be given.
 
-    Raises:
-        AssertionError: If the physical size `phys_size` does not have the expected format or the length of `phys_size` does not match the dimension of the input array.
-    """
+  Returns:
+      A tuple with four elements. The first is a Boolean array obtained by
+      squeezing and binarizing the input array, the second is an array that
+      contains the pixel size, the third is the length of the shorter side of
+      the pixel, and the fourth is the length of the shorter side of the image.
 
-    arr = np.squeeze(arr)
+  Raises:
+      AssertionError: If the physical size `phys_size` does not have the
+      expected format or the length of `phys_size` does not match the dimension
+      of the input array.
+  """
 
-    if isinstance(phys_size, np.ndarray) or isinstance(
-            phys_size, list) or isinstance(phys_size, tuple):
-        phys_size = np.squeeze(phys_size)
-        phys_size = phys_size[
-            phys_size.nonzero()]  # keep nonzero elements only
-    elif isinstance(phys_size, float) or isinstance(phys_size, int):
-        phys_size = [phys_size]
-    elif phys_size is None:
-        phys_size = arr.shape
-    else:
-        AssertionError("Invalid format of the physical size.")
+  array = np.squeeze(array)
 
-    assert arr.ndim == len(
-        phys_size
-    ), 'The physical size and the dimension of the input array do not match.'
-    assert arr.ndim in (
-        1, 2), 'The current version of imageruler only supports 1d and 2d.'
+  if (
+      isinstance(phys_size, np.ndarray)
+      or isinstance(phys_size, list)
+      or isinstance(phys_size, tuple)
+  ):
+    phys_size = np.squeeze(phys_size)
+    phys_size = phys_size[phys_size.nonzero()]  # keep nonzero elements only
+  elif isinstance(phys_size, float) or isinstance(phys_size, int):
+    phys_size = [phys_size]
+  elif phys_size is None:
+    phys_size = array.shape
+  else:
+    raise AssertionError('Invalid format of the physical size.')
 
-    short_entire_side = min(
-        phys_size)  # shorter side of the entire design region
-    pixel_size = _get_pixel_size(arr, phys_size)
-    short_pixel_side = min(pixel_size)  # shorter side of a pixel
-    arr = _binarize(arr)  # Boolean array
+  assert array.ndim == len(
+      phys_size
+  ), 'The physical size and the dimension of the input array do not match.'
+  assert array.ndim in (
+      1,
+      2,
+  ), 'The current version of imageruler only supports 1d and 2d.'
 
-    if periodic_axes is not None:
-        if arr.ndim == 2:
-            periodic_axes = np.array(periodic_axes)
-            reps = (2 if 0 in periodic_axes else 1,
-                    2 if 1 in periodic_axes else 1)
-            arr = np.tile(arr, reps)
-            phys_size = np.array(phys_size) * reps
-            short_entire_side = min(
-                phys_size)  # shorter side of the entire design region
-        else:  # arr.ndim == 1
-            arr = np.tile(arr, 2)
-            short_entire_side *= 2
+  short_entire_side = min(phys_size)  # shorter side of the entire design region
+  pixel_size = _get_pixel_size(array, phys_size)
+  short_pixel_side = min(pixel_size)  # shorter side of a pixel
+  array = _binarize(array)  # Boolean array
 
-    if warn_cusp and arr.ndim == 2:
-        harris = cv.cornerHarris(arr.astype(np.uint8),
-                                 blockSize=5,
-                                 ksize=5,
-                                 k=0.04)
-        if np.max(harris) > 5e-10:
-            warnings.warn("This image may contain sharp corners or cusps.")
+  if periodic_axes is not None:
+    if array.ndim == 2:
+      periodic_axes = np.array(periodic_axes)
+      reps = (2 if 0 in periodic_axes else 1, 2 if 1 in periodic_axes else 1)
+      array = np.tile(array, reps)
+      phys_size = np.array(phys_size) * reps
+      short_entire_side = min(
+          phys_size
+      )  # shorter side of the entire design region
+    else:  # arr.ndim == 1
+      array = np.tile(array, 2)
+      short_entire_side *= 2
 
-    return arr, pixel_size, short_pixel_side, short_entire_side
+  if warn_cusp and array.ndim == 2:
+    harris = cv.cornerHarris(
+        array.astype(np.uint8), blockSize=5, ksize=5, k=0.04
+    )
+    if np.max(harris) > 5e-10:
+      warnings.warn('This image may contain sharp corners or cusps.')
+
+  return array, pixel_size, short_pixel_side, short_entire_side
 
 
 def _search(arg_range, arg_threshold, function):
-    """
-    Binary search.
+  """Binary search.
 
-    Args:
-        arg_range: Initial range of the argument under search.
-        arg_threshold: Threshold of the argument range, below which the search stops.
-        function: A function that returns True if the viariable is large enough but False if the variable is not large enough.
+  Args:
+      arg_range: Initial range of the argument under search.
+      arg_threshold: Threshold of the argument range, below which the search
+        stops.
+      function: A function that returns True if the viariable is large enough
+        but False if the variable is not large enough.
 
-    Returns:
-        A tuple with two elements. The first is a float that represents the search result. The second is a Boolean value, which is True if the search indeed happens, False if the condition for starting search is not satisfied in the beginning.
+  Returns:
+      A tuple with two elements. The first is a float that represents the search
+      result. The second is a Boolean value, which is True if the search indeed
+      happens, False if the condition for starting search is not satisfied in
+      the beginning.
 
-    Raises:
-        AssertionError: If `function` returns True at a smaller input viariable but False at a larger input viariable.
-    """
+  Raises:
+      AssertionError: If `function` returns True at a smaller input viariable
+      but False at a larger input viariable.
+  """
 
-    args = [
-        min(arg_range), (min(arg_range) + max(arg_range)) / 2,
-        max(arg_range)
-    ]
+  args = [min(arg_range), (min(arg_range) + max(arg_range)) / 2, max(arg_range)]
 
-    if not function(args[0]) and function(args[2]):
-        while abs(args[0] - args[2]) > arg_threshold:
-            arg = args[1]
-            if not function(arg):
-                args[0], args[1] = arg, (
-                    arg + args[2]) / 2  # The current value is too small
-            else:
-                args[1], args[2] = (
-                    arg + args[0]) / 2, arg  # The current value is still large
-        return args[1], True
-    elif not function(args[0]) and not function(args[2]):
-        return args[2], False
-    elif function(args[0]) and function(args[2]):
-        return args[0], False
-    else:
-        raise AssertionError("The function is not monotonically increasing.")
+  if not function(args[0]) and function(args[2]):
+    while abs(args[0] - args[2]) > arg_threshold:
+      arg = args[1]
+      if not function(arg):
+        args[0], args[1] = (
+            arg,
+            (arg + args[2]) / 2,
+        )  # The current value is too small
+      else:
+        args[1], args[2] = (
+            arg + args[0]
+        ) / 2, arg  # The current value is still large
+    return args[1], True
+  elif not function(args[0]) and not function(args[2]):
+    return args[2], False
+  elif function(args[0]) and function(args[2]):
+    return args[0], False
+  else:
+    raise AssertionError('The function is not monotonically increasing.')
 
 
 def _minimum_length_1d(arr):
-    """
-    Search the minimum lengths of solid and void segments in a 1d array.
+  """Search the minimum lengths of solid and void segments in a 1d array.
 
-    Args:
-        arr: A 1d Boolean array.
+  Args:
+      arr: A 1d Boolean array.
 
-    Return:
-        A tuple of two integers. The first and second intergers represent the numbers of pixels in the shortest solid and void segments, respectively.
-    """
+  Returns:
+      A tuple of two integers. The first and second intergers represent the
+        numbers of pixels in the shortest solid and void segments, respectively.
+  """
 
-    arr = np.append(arr, ~arr[-1])
-    solid_lengths, void_lengths = [], []
-    counter = 0
+  arr = np.append(arr, ~arr[-1])
+  solid_lengths, void_lengths = [], []
+  counter = 0
 
-    for idx in range(len(arr) - 1):
-        counter += 1
+  for idx in range(len(arr) - 1):
+    counter += 1
 
-        if arr[idx] != arr[idx + 1]:
-            if arr[idx]:
-                solid_lengths.append(counter)
-            else:
-                void_lengths.append(counter)
-            counter = 0
+    if arr[idx] != arr[idx + 1]:
+      if arr[idx]:
+        solid_lengths.append(counter)
+      else:
+        void_lengths.append(counter)
+      counter = 0
 
-    if len(solid_lengths) > 0:
-        solid_min_length = min(solid_lengths)
-    else:
-        solid_min_length = 0
+  if len(solid_lengths) > 0:
+    solid_min_length = min(solid_lengths)
+  else:
+    solid_min_length = 0
 
-    if len(void_lengths) > 0:
-        void_min_length = min(void_lengths)
-    else:
-        void_min_length = 0
+  if len(void_lengths) > 0:
+    void_min_length = min(void_lengths)
+  else:
+    void_min_length = 0
 
-    return solid_min_length, void_min_length
+  return solid_min_length, void_min_length
 
 
 def _get_interior(arr, direction, pad_mode):
-    """
-    Get inner borders, outer borders, or union of both inner and outer borders of solid regions.
+  """Gets inner borders, outer borders, or union of inner and outer borders.
 
-    Args:
-        arr: A 2d array that represents an image.
-        direction: A string that can be "in", "out", or "both" to indicate inner borders, outer borders, and union of inner and outer borders.
+  Args:
+    arr: A 2d array that represents an image.
+    direction: A string that can be "in", "out", or "both" to indicate inner
+      borders, outer borders, and union of inner and outer borders.
+    pad_mode: The padding mode to use.
 
-    Returns:
-        A Boolean array in which all True elements are at and only at borders.
+  Returns:
+      A Boolean array in which all True elements are at and only at borders.
 
-    Raises:
-        AssertionError: If the option provided to `direction` is not 'in', 'out', or 'both'.
-    """
+  Raises:
+      AssertionError: If the option provided to `direction` is not 'in', 'out',
+      or 'both'.
+  """
 
-    pixel_size = (1, ) * arr.ndim
-    diameter = 2.8  # With this pixel size and diameter, the resulting kernel has the shape of a plus sign.
+  pixel_size = (1,) * arr.ndim
+  # With this pixel size and diameter, the resulting kernel has the shape of a
+  # plus sign.
+  diameter = 2.8
 
-    if direction == 'in':  # interior of solid regions
-        return binary_erode(arr, diameter, pixel_size, pad_mode)
-    elif direction == 'out':  # interior of void regions
-        return ~binary_dilate(arr, diameter, pixel_size, pad_mode)
-    elif direction == 'both':  # union of interiors of solid and void regions
-        eroded = binary_erode(arr, diameter, pixel_size, pad_mode[0])
-        dilated = binary_dilate(arr, diameter, pixel_size, pad_mode[1])
-        return ~dilated | eroded
-    else:
-        raise AssertionError(
-            "The direction at the border can only be in, out, or both.")
-
-
-def _get_pixel_size(arr, phys_size):
-    """
-    Compute the physical size of a single pixel.
-
-    Args:
-        arr: An array that represents an image.
-        phys_size: A tuple that represents the physical size of the image.
-
-    Returns:
-        An array of floats. It represents the physical size of a single pixel.
-    """
-
-    squeeze_shape = np.array(np.squeeze(arr).shape)
-    return phys_size / squeeze_shape  # sizes of a pixel along all finite-thickness directions
-
-
-def _binarize(arr):
-    """
-    Binarize the input array according to the threshold.
-
-    Args:
-        arr: An array that represents an image.
-
-    Returns:
-        An Boolean array.
-    """
-
-    return arr > threshold * max(arr.flatten()) + (1 - threshold) * min(
-        arr.flatten())
-
-
-def _get_kernel(diameter, pixel_size):
-    """
-    Get the kernel with a given diameter and pixel size.
-
-    Args:
-        diameter: A float that represents the diameter of the kernel, which acts like a probe.
-        pixel_size: A tuple, list, or array that represents the physical size of one pixel in the image.
-
-    Returns:
-        An array of unsigned integers 0 and 1. It represent the kernel for morpological operations.
-    """
-
-    pixel_size = np.array(pixel_size)
-    se_shape = np.array(np.round(diameter / pixel_size), dtype=int)
-
-    if se_shape[0] <= 2 and se_shape[1] <= 2:
-        return np.ones(se_shape, dtype=np.uint8)
-
-    rounded_size = np.round(diameter / pixel_size - 1) * pixel_size
-
-    x_tick = np.linspace(-rounded_size[0] / 2, rounded_size[0] / 2,
-                         se_shape[0])
-    y_tick = np.linspace(-rounded_size[1] / 2, rounded_size[1] / 2,
-                         se_shape[1])
-
-    X, Y = np.meshgrid(x_tick, y_tick, sparse=True,
-                       indexing='ij')  # grid over the entire design region
-    structuring_element = X**2 + Y**2 <= diameter**2 / 4
-
-    return np.array(structuring_element, dtype=np.uint8)
-
-
-def binary_open(arr: np.ndarray,
-                diameter: float,
-                pixel_size: Tuple[float, float] = (1.0, 1.0),
-                pad_mode: str = 'edge') -> np.ndarray:
-    """
-    Morphological opening.
-
-    Args:
-        arr: A binarized 2d array that represents a binary image.
-        diameter: A float that represents the diameter of the kernel, which acts like a probe.
-        pixel_size: A tuple, list, or array that represents the physical size of one pixel in the image.
-        pad_mode: A string that represents the padding mode, which can be 'solid', 'void', or 'edge'.
-
-    Returns:
-        A Boolean array that represents the outcome of morphological opening. 
-    """
-
-    kernel = _get_kernel(diameter, pixel_size)
-    arr = _proper_pad(arr, kernel, pad_mode)
-    opened = cv.morphologyEx(src=arr, kernel=kernel, op=cv.MORPH_OPEN)
-
-    return _proper_unpad(opened, kernel).astype(bool)
-
-
-def binary_close(arr: np.ndarray,
-                 diameter: float,
-                 pixel_size: Tuple[float, float] = (1.0, 1.0),
-                 pad_mode: str = 'edge') -> np.ndarray:
-    """
-    Morphological closing.
-
-    Args:
-        arr: A binarized 2d array that represents a binary image.
-        diameter: A float that represents the diameter of the kernel, which acts like a probe.
-        pixel_size: A tuple, list, or array that represents the physical size of one pixel in the image.
-        pad_mode: A string that represents the padding mode, which can be 'solid', 'void', or 'edge'.
-
-    Returns:
-        A Boolean array that represents the outcome of morphological closing. 
-    """
-
-    kernel = _get_kernel(diameter, pixel_size)
-    arr = _proper_pad(arr, kernel, pad_mode)
-    closed = cv.morphologyEx(src=arr, kernel=kernel, op=cv.MORPH_CLOSE)
-
-    return _proper_unpad(closed, kernel).astype(bool)
-
-
-def binary_erode(arr: np.ndarray,
-                 diameter: float,
-                 pixel_size: Tuple[float, float] = (1.0, 1.0),
-                 pad_mode: str = 'edge') -> np.ndarray:
-    """
-    Morphological erosion.
-
-    Args:
-        arr: A binarized 2d array that represents a binary image.
-        diameter: A float that represents the diameter of the kernel, which acts like a probe.
-        pixel_size: A tuple, list, or array that represents the physical size of one pixel in the image.
-        pad_mode: A string that represents the padding mode, which can be 'solid', 'void', or 'edge'.
-
-    Returns:
-        A Boolean array that represents the outcome of morphological erosion. 
-    """
-
-    kernel = _get_kernel(diameter, pixel_size)
-    arr = _proper_pad(arr, kernel, pad_mode)
-    eroded = cv.erode(arr, kernel)
-
-    return _proper_unpad(eroded, kernel).astype(bool)
-
-
-def binary_dilate(arr: np.ndarray,
-                  diameter: float,
-                  pixel_size: Tuple[float, float] = (1.0, 1.0),
-                  pad_mode: str = 'edge') -> np.ndarray:
-    """
-    Morphological dilation.
-
-    Args:
-        arr: A binarized 2d array that represents a binary image.
-        diameter: A float that represents the diameter of the kernel, which acts like a probe.
-        pixel_size: A tuple, list, or array that represents the physical size of one pixel in the image.
-        pad_mode: A string that represents the padding mode, which can be 'solid', 'void', or 'edge'.
-
-    Returns:
-        A Boolean array that represents the outcome of morphological dilation. 
-    """
-
-    kernel = _get_kernel(diameter, pixel_size)
-    arr = _proper_pad(arr, kernel, pad_mode)
-    dilated = cv.dilate(arr, kernel)
-
-    return _proper_unpad(dilated, kernel).astype(bool)
-
-
-def _proper_pad(arr, kernel, pad_mode):
-    """
-    Pad the input array properly according to the size of the kernel.
-
-    Args:
-        arr: A binarized 2d array that represents a binary image.
-        kernel: A 2d array that represents the kernel of morphological operations.
-        pad_mode: A string that represents the padding mode, which can be 'solid', 'void', or 'edge'.
-
-    Returns:
-        A padded array composed of unsigned integers 0 and 1.
-
-    Raises:
-        AssertionError: If `pad_mode` is not `solid`, `void`, or `edge`.
-    """
-
-    ((top, bottom), (left, right)) = ((kernel.shape[0], ) * 2,
-                                      (kernel.shape[1], ) * 2)
-
-    if pad_mode == 'edge':
-        return cv.copyMakeBorder(arr.view(np.uint8),
-                                 top=top,
-                                 bottom=bottom,
-                                 left=left,
-                                 right=right,
-                                 borderType=cv.BORDER_REPLICATE)
-    elif pad_mode == 'solid':
-        return cv.copyMakeBorder(arr.view(np.uint8),
-                                 top=top,
-                                 bottom=bottom,
-                                 left=left,
-                                 right=right,
-                                 borderType=cv.BORDER_CONSTANT,
-                                 value=1)
-    elif pad_mode == 'void':
-        return cv.copyMakeBorder(arr.view(np.uint8),
-                                 top=top,
-                                 bottom=bottom,
-                                 left=left,
-                                 right=right,
-                                 borderType=cv.BORDER_CONSTANT,
-                                 value=0)
-    else:
-        raise AssertionError(
-            "The padding mode should be 'solid', 'void', or 'edge'.")
-
-
-def _proper_unpad(arr, kernel):
-    """
-    Remove padding according to the size of the kernel. The code is copied from Martin F. Schubert's code at 
-    https://github.com/mfschubert/topology/blob/main/metrics.py
-
-    Args:
-        arr: A 2d array that has extra padding.
-        kernel: A 2d array that represents the kernel of morphological operations.
-
-    Returns:
-        A 2d array without padding.
-    """
-
-    unpad_width = (
-        (
-            kernel.shape[0] + (kernel.shape[0] + 1) % 2,
-            kernel.shape[0] - (kernel.shape[0] + 1) % 2,
-        ),
-        (
-            kernel.shape[1] + (kernel.shape[1] + 1) % 2,
-            kernel.shape[1] - (kernel.shape[1] + 1) % 2,
-        ),
+  if direction == 'in':  # interior of solid regions
+    return binary_erode(arr, diameter, pixel_size, pad_mode)
+  elif direction == 'out':  # interior of void regions
+    return ~binary_dilate(arr, diameter, pixel_size, pad_mode)
+  elif direction == 'both':  # union of interiors of solid and void regions
+    eroded = binary_erode(arr, diameter, pixel_size, pad_mode[0])
+    dilated = binary_dilate(arr, diameter, pixel_size, pad_mode[1])
+    return ~dilated | eroded
+  else:
+    raise AssertionError(
+        'The direction at the border can only be in, out, or both.'
     )
 
-    slices = tuple([
-        slice(pad_lo, dim - pad_hi)
-        for (pad_lo, pad_hi), dim in zip(unpad_width, arr.shape)
-    ])
-    return arr[slices]
+
+def _get_pixel_size(array: np.ndarray, phys_size: PhysicalSize):
+  """Compute the physical size of a single pixel.
+
+  Args:
+      array: An array that represents an image.
+      phys_size: A tuple that represents the physical size of the image.
+
+  Returns:
+      An array of floats. It represents the physical size of a single pixel.
+  """
+
+  squeeze_shape = np.array(np.squeeze(array).shape)
+  return (
+      phys_size / squeeze_shape
+  )  # sizes of a pixel along all finite-thickness directions
 
 
-def _trim(arr: np.ndarray, margin_size: Tuple, pixel_size: Tuple) -> np.ndarray:
-    """Returns the array with the margins removed.
+def _binarize(array: np.ndarray) -> np.ndarray:
+  """Binarize the input array according to the threshold.
 
-    Args:
-        arr: The image as a 1d or 2d array.
-        margin_size: The physical dimensions of the image margins. If specified,
-            this subregion is excluded from the result. No default.
-        pixel_size: The physical size of one pixel in the image. No default.
+  Args:
+      array: An array that represents an image.
 
-    Returns:
-        A subarray of the input array.
+  Returns:
+      An Boolean array.
+  """
 
-    Raises:
-        AssertionError: If `margin_size` implies more dimensions than the
-            dimension of the input array `arr`, or the regions to be
-            disregarded is too wide.
-    """
+  return array > _BINARIZATION_THRESHOLD * max(array.flatten()) + (
+      1 - _BINARIZATION_THRESHOLD
+  ) * min(array.flatten())
 
-    arr = np.squeeze(arr)
-    arr_dim = arr.ndim
-    margin_size = abs(np.reshape(margin_size, (-1, 2)))
-    margin_dim = len(margin_size)
 
-    if margin_dim > arr_dim:
-        raise AssertionError("The number of rows of margin_size should not "
-                             "exceed the dimension of the input array.")
+def _get_kernel(diameter: float, pixel_size: PixelSize) -> np.ndarray:
+  """Get the kernel with a given diameter and pixel size.
 
-    margin_number = np.array(
-        margin_size) / pixel_size[0:len(margin_size)].reshape(
-            len(margin_size), 1)
-    margin_number = np.round(margin_number).astype(
-        int)  # numbers of pixels of marginal regions
+  Args:
+      diameter: A float that represents the diameter of the kernel, which acts
+        like a probe.
+      pixel_size: A tuple, list, or array that represents the physical size of
+        one pixel in the image.
 
-    if (np.array(arr.shape)[0:margin_dim] -
-        np.sum(margin_number, axis=1) < 2).all():
-        raise AssertionError("The design region is too narrow or contains "
-                             "margins which are too wide.")
+  Returns:
+      An array of unsigned integers 0 and 1. It represent the kernel for
+      morpological operations.
+  """
 
-    if margin_dim == 1:
-        return arr[margin_number[0][0]:-margin_number[0][1]]
-    elif margin_dim == 2:
-        return arr[margin_number[0][0]:-margin_number[0][1],
-                   margin_number[1][0]:-margin_number[1][1]]
-    else:
-        raise AssertionError("The input array has too many dimensions.")
+  pixel_size = np.array(pixel_size)
+  se_shape = np.array(np.round(diameter / pixel_size), dtype=int)
+
+  if se_shape[0] <= 2 and se_shape[1] <= 2:
+    return np.ones(se_shape, dtype=np.uint8)
+
+  rounded_size = np.round(diameter / pixel_size - 1) * pixel_size
+
+  x_tick = np.linspace(-rounded_size[0] / 2, rounded_size[0] / 2, se_shape[0])
+  y_tick = np.linspace(-rounded_size[1] / 2, rounded_size[1] / 2, se_shape[1])
+
+  x, y = np.meshgrid(
+      x_tick, y_tick, sparse=True, indexing='ij'
+  )  # grid over the entire design region
+  structuring_element = x**2 + y**2 <= diameter**2 / 4
+
+  return np.array(structuring_element, dtype=np.uint8)
+
+
+def binary_open(
+    array: np.ndarray,
+    diameter: float,
+    pixel_size: PixelSize = (1.0, 1.0),
+    pad_mode: PaddingMode = PaddingMode.EDGE,
+) -> np.ndarray:
+  """Applies a binary morphological opening.
+
+  Args:
+    array: A binarized 2d array that represents a binary image.
+    diameter: A float that represents the diameter of the kernel, which acts
+      like a probe.
+    pixel_size: A tuple, list, or array that represents the physical size of one
+      pixel in the image.
+    pad_mode: A string that represents the padding mode, which can be 'solid',
+      'void', or 'edge'.
+
+  Returns:
+    A Boolean array that represents the outcome of morphological opening.
+  """
+  kernel = _get_kernel(diameter, pixel_size)
+  array = _proper_pad(array, kernel, pad_mode)
+  opened = cv.morphologyEx(src=array, kernel=kernel, op=cv.MORPH_OPEN)
+  return _proper_unpad(opened, kernel).astype(bool)
+
+
+def binary_close(
+    arr: np.ndarray,
+    diameter: float,
+    pixel_size: PixelSize = (1.0, 1.0),
+    pad_mode: PaddingMode = PaddingMode.EDGE,
+) -> np.ndarray:
+  """Applies a binary morphological closing.
+
+  Args:
+    arr: A binarized 2d array that represents a binary image.
+    diameter: A float that represents the diameter of the kernel, which acts
+      like a probe.
+    pixel_size: A tuple, list, or array that represents the physical size of one
+      pixel in the image.
+    pad_mode: A string that represents the padding mode, which can be 'solid',
+      'void', or 'edge'.
+
+  Returns:
+      A Boolean array that represents the outcome of morphological closing.
+  """
+  kernel = _get_kernel(diameter, pixel_size)
+  arr = _proper_pad(arr, kernel, pad_mode)
+  closed = cv.morphologyEx(src=arr, kernel=kernel, op=cv.MORPH_CLOSE)
+  return _proper_unpad(closed, kernel).astype(bool)
+
+
+def binary_erode(
+    array: np.ndarray,
+    diameter: float,
+    pixel_size: PixelSize = (1.0, 1.0),
+    pad_mode: PaddingMode = PaddingMode.EDGE,
+) -> np.ndarray:
+  """Applies a binary morphological erosion.
+
+  Args:
+    array: A binarized 2d array that represents a binary image.
+    diameter: A float that represents the diameter of the kernel, which acts
+      like a probe.
+    pixel_size: A tuple, list, or array that represents the physical size of one
+      pixel in the image.
+    pad_mode: A string that represents the padding mode, which can be 'solid',
+      'void', or 'edge'.
+
+  Returns:
+    A Boolean array that represents the outcome of morphological erosion.
+  """
+
+  kernel = _get_kernel(diameter, pixel_size)
+  array = _proper_pad(array, kernel, pad_mode)
+  eroded = cv.erode(array, kernel)
+
+  return _proper_unpad(eroded, kernel).astype(bool)
+
+
+def binary_dilate(
+    array: np.ndarray,
+    diameter: float,
+    pixel_size: PixelSize = (1.0, 1.0),
+    pad_mode: PaddingMode = PaddingMode.EDGE,
+) -> np.ndarray:
+  """Applies a binary morphological dilation.
+
+  Args:
+    array: A binarized 2d array that represents a binary image.
+    diameter: A float that represents the diameter of the kernel, which acts
+      like a probe.
+    pixel_size: A tuple, list, or array that represents the physical size of one
+      pixel in the image.
+    pad_mode: A string that represents the padding mode, which can be 'solid',
+      'void', or 'edge'.
+
+  Returns:
+    A Boolean array that represents the outcome of morphological dilation.
+  """
+
+  kernel = _get_kernel(diameter, pixel_size)
+  array = _proper_pad(array, kernel, pad_mode)
+  dilated = cv.dilate(array, kernel)
+
+  return _proper_unpad(dilated, kernel).astype(bool)
+
+
+def _proper_pad(
+    array: np.ndarray, kernel: np.ndarray, pad_mode: PaddingMode
+) -> np.ndarray:
+  """Pad the input array properly according to the size of the kernel.
+
+  Args:
+    array: A binarized 2d array that represents a binary image.
+    kernel: A 2d array that represents the kernel of morphological operations.
+    pad_mode: A string that represents the padding mode, which can be 'solid',
+      'void', or 'edge'.
+
+  Returns:
+    A padded array composed of unsigned integers 0 and 1.
+  """
+
+  ((top, bottom), (left, right)) = (
+      (kernel.shape[0],) * 2,
+      (kernel.shape[1],) * 2,
+  )
+
+  if pad_mode is PaddingMode.EDGE:
+    return cv.copyMakeBorder(
+        array.view(np.uint8),
+        top=top,
+        bottom=bottom,
+        left=left,
+        right=right,
+        borderType=cv.BORDER_REPLICATE,
+    )
+  elif pad_mode is PaddingMode.SOLID:
+    return cv.copyMakeBorder(
+        array.view(np.uint8),
+        top=top,
+        bottom=bottom,
+        left=left,
+        right=right,
+        borderType=cv.BORDER_CONSTANT,
+        value=1,
+    )
+  elif pad_mode is PaddingMode.VOID:
+    return cv.copyMakeBorder(
+        array.view(np.uint8),
+        top=top,
+        bottom=bottom,
+        left=left,
+        right=right,
+        borderType=cv.BORDER_CONSTANT,
+        value=0,
+    )
+  else:
+    raise ValueError(f'Unknown padding mode: {pad_mode.name}.')
+
+
+def _proper_unpad(array: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+  """Removes padding according to the size of the kernel.
+
+  The code is copied from Martin F. Schubert's code at
+  https://github.com/mfschubert/topology/blob/main/metrics.py
+
+  Args:
+    array: A 2d array that has extra padding.
+    kernel: A 2d array that represents the kernel of morphological operations.
+
+  Returns:
+    A 2d array without padding.
+  """
+
+  unpad_width = (
+      (
+          kernel.shape[0] + (kernel.shape[0] + 1) % 2,
+          kernel.shape[0] - (kernel.shape[0] + 1) % 2,
+      ),
+      (
+          kernel.shape[1] + (kernel.shape[1] + 1) % 2,
+          kernel.shape[1] - (kernel.shape[1] + 1) % 2,
+      ),
+  )
+
+  slices = tuple(
+      [
+          slice(pad_lo, dim - pad_hi)
+          for (pad_lo, pad_hi), dim in zip(unpad_width, array.shape)
+      ]
+  )
+  return array[slices]
+
+
+def _trim(
+    array: np.ndarray, margin_size: MarginSize, pixel_size: PixelSize
+) -> np.ndarray:
+  """Trims margins from an array.
+
+  Args:
+    array: The image as a 1d or 2d array.
+    margin_size: The physical dimensions of the image margins. If specified,
+      this subregion is excluded from the result. No default.
+    pixel_size: The physical size of one pixel in the image. No default.
+
+  Returns:
+    A subarray of the input array.
+  """
+
+  array = np.squeeze(array)
+  arr_dim = array.ndim
+  margin_size = abs(np.reshape(margin_size, (-1, 2)))
+  margin_dim = len(margin_size)
+
+  if margin_dim > arr_dim:
+    raise ValueError(
+        'The number of rows of margin_size should not '
+        'exceed the dimension of the input array.'
+    )
+
+  pixel_size = np.asarray(pixel_size)
+  margin_number = np.array(margin_size) / pixel_size[
+      0 : len(margin_size)
+  ].reshape(len(margin_size), 1)
+  margin_number = np.round(margin_number).astype(
+      int
+  )  # numbers of pixels of marginal regions
+
+  if (
+      np.array(array.shape)[0:margin_dim] - np.sum(margin_number, axis=1) < 2
+  ).all():
+    raise ValueError(
+        'The design region is too narrow or contains '
+        'margins which are too wide.'
+    )
+
+  if margin_dim == 1:
+    return array[margin_number[0][0] : -margin_number[0][1]]
+  elif margin_dim == 2:
+    return array[
+        margin_number[0][0] : -margin_number[0][1],
+        margin_number[1][0] : -margin_number[1][1],
+    ]
+  else:
+    raise ValueError('The input array has too many dimensions.')

--- a/imageruler/imageruler.py
+++ b/imageruler/imageruler.py
@@ -1,7 +1,7 @@
 """Imageruler for measuring minimum lengthscales in binary images."""
 
 import enum
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple, Union
 import warnings
 import cv2 as cv
 import numpy as np
@@ -163,7 +163,7 @@ def minimum_length(
     phys_size: Optional[PhysicalSize] = None,
     periodic_axes: Optional[PeriodicAxes] = None,
     margin_size: Optional[MarginSize] = None,
-    pad_mode: PaddingMode | Tuple[PaddingMode, PaddingMode] = (
+    pad_mode: Union[PaddingMode, Tuple[PaddingMode, PaddingMode]] = (
         PaddingMode.SOLID,
         PaddingMode.VOID,
     ),

--- a/imageruler/imageruler.py
+++ b/imageruler/imageruler.py
@@ -547,7 +547,11 @@ def _minimum_length_1d(array: np.ndarray) -> Tuple[int, int]:
   return solid_min_length, void_min_length
 
 
-def _get_interior(array: np.ndarray, direction: str, pad_mode: PaddingMode):
+def _get_interior(
+    array: np.ndarray,
+    direction: str,
+    pad_mode: Union[PaddingMode, Tuple[PaddingMode, PaddingMode]],
+):
   """Gets inner borders, outer borders, or union of inner and outer borders.
 
   Args:

--- a/imageruler/regular_shapes.py
+++ b/imageruler/regular_shapes.py
@@ -1,130 +1,171 @@
-import numpy as np
+"""Regular shapes."""
+
 from typing import Tuple
+import numpy as np
 
 
-def rounded_square(resolution: float,
-                   phys_size: Tuple[float, float],
-                   declared_mls: float,
-                   center: Tuple[float, float] = (0, 0),
-                   angle: float = 0) -> np.ndarray:
-    """
-    Return a Boolean array where all True elements form a square with rounded corners.
+def rounded_square(
+    resolution: float,
+    phys_size: Tuple[float, float],
+    declared_mls: float,
+    center: Tuple[float, float] = (0, 0),
+    angle: float = 0,
+) -> np.ndarray:
+  """Return a Boolean array where all True elements form a square with rounded corners.
 
-    Args:
-        resolution: A float that represents the number of points per unit length.
-        phys_size: A tuple with two elements that describe the physical size of the entire pattern.
-        declared_mls: A float that represents the declared minimum length scale, which is equal to the diameter of round corners.
-        center: A tuple with two elements that describe the coordinates of the center of the square.
-        angle: A float that represents the angle of rotation in degree.
+  Args:
+      resolution: A float that represents the number of points per unit length.
+      phys_size: A tuple with two elements that describe the physical size of
+        the entire pattern.
+      declared_mls: A float that represents the declared minimum length scale,
+        which is equal to the diameter of round corners.
+      center: A tuple with two elements that describe the coordinates of the
+        center of the square.
+      angle: A float that represents the angle of rotation in degree.
 
-    Returns:
-        An array with Boolean elements. 
-    """
+  Returns:
+      An array with Boolean elements.
+  """
 
-    phys_size = np.array(phys_size)
-    angle = np.radians(angle)
+  phys_size = np.array(phys_size)
+  angle = np.radians(angle)
 
-    n = np.round(phys_size * resolution).astype(
-        int)  # number of pixels along each dimension
-    grid_size = (
-        n - 1
-    ) / resolution  # size of the entire pattern formed by centers of pixels
+  n = np.round(phys_size * resolution).astype(
+      int
+  )  # number of pixels along each dimension
+  grid_size = (
+      n - 1
+  ) / resolution  # size of the entire pattern formed by centers of pixels
 
-    x_coord = np.linspace(-grid_size[0] / 2, grid_size[0] / 2, n[0])
-    y_coord = np.linspace(-grid_size[1] / 2, grid_size[1] / 2, n[1])
-    xv, yv = np.meshgrid(x_coord, y_coord, sparse=True, indexing='ij')
+  x_coord = np.linspace(-grid_size[0] / 2, grid_size[0] / 2, n[0])
+  y_coord = np.linspace(-grid_size[1] / 2, grid_size[1] / 2, n[1])
+  xv, yv = np.meshgrid(x_coord, y_coord, sparse=True, indexing='ij')
 
-    side, diameter = 2 * declared_mls, declared_mls
-    rect_vert = (abs(
-        np.sin(angle) * (xv - center[0]) - np.cos(angle) * (yv - center[1])) <=
-                 (side - diameter) / 2) & (abs(
-                     np.cos(angle) * (xv - center[0]) + np.sin(angle) *
-                     (yv - center[1])) <= side / 2)
-    rect_hori = (abs(
-        np.sin(angle) * (xv - center[0]) - np.cos(angle) *
-        (yv - center[1])) <= side / 2) & (abs(
-            np.cos(angle) * (xv - center[0]) + np.sin(angle) *
-            (yv - center[1])) <= (side - diameter) / 2)
+  side, diameter = 2 * declared_mls, declared_mls
+  rect_vert = (
+      abs(np.sin(angle) * (xv - center[0]) - np.cos(angle) * (yv - center[1]))
+      <= (side - diameter) / 2
+  ) & (
+      abs(np.cos(angle) * (xv - center[0]) + np.sin(angle) * (yv - center[1]))
+      <= side / 2
+  )
+  rect_hori = (
+      abs(np.sin(angle) * (xv - center[0]) - np.cos(angle) * (yv - center[1]))
+      <= side / 2
+  ) & (
+      abs(np.cos(angle) * (xv - center[0]) + np.sin(angle) * (yv - center[1]))
+      <= (side - diameter) / 2
+  )
 
-    disc_centers = np.array([[
-        side - diameter, diameter - side, diameter - side, side - diameter
-    ], [side - diameter, side - diameter, diameter - side, diameter - side]
-                             ]) / 2
-    disc_centers_x = disc_centers[0, :] * np.cos(angle) - disc_centers[
-        1, :] * np.sin(angle) + center[0]
-    disc_centers_y = disc_centers[0, :] * np.sin(angle) + disc_centers[
-        1, :] * np.cos(angle) + center[1]
-    disc_centers = np.vstack((disc_centers_x, disc_centers_y))
+  disc_centers = (
+      np.array([
+          [
+              side - diameter,
+              diameter - side,
+              diameter - side,
+              side - diameter,
+          ],
+          [
+              side - diameter,
+              side - diameter,
+              diameter - side,
+              diameter - side,
+          ],
+      ])
+      / 2
+  )
+  disc_centers_x = (
+      disc_centers[0, :] * np.cos(angle)
+      - disc_centers[1, :] * np.sin(angle)
+      + center[0]
+  )
+  disc_centers_y = (
+      disc_centers[0, :] * np.sin(angle)
+      + disc_centers[1, :] * np.cos(angle)
+      + center[1]
+  )
+  disc_centers = np.vstack((disc_centers_x, disc_centers_y))
 
-    disc0 = (xv - disc_centers[0, 0])**2 + (
-        yv - disc_centers[1, 0])**2 <= diameter**2 / 4
-    disc1 = (xv - disc_centers[0, 1])**2 + (
-        yv - disc_centers[1, 1])**2 <= diameter**2 / 4
-    disc2 = (xv - disc_centers[0, 2])**2 + (
-        yv - disc_centers[1, 2])**2 <= diameter**2 / 4
-    disc3 = (xv - disc_centers[0, 3])**2 + (
-        yv - disc_centers[1, 3])**2 <= diameter**2 / 4
+  disc0 = (xv - disc_centers[0, 0]) ** 2 + (
+      yv - disc_centers[1, 0]
+  ) ** 2 <= diameter**2 / 4
+  disc1 = (xv - disc_centers[0, 1]) ** 2 + (
+      yv - disc_centers[1, 1]
+  ) ** 2 <= diameter**2 / 4
+  disc2 = (xv - disc_centers[0, 2]) ** 2 + (
+      yv - disc_centers[1, 2]
+  ) ** 2 <= diameter**2 / 4
+  disc3 = (xv - disc_centers[0, 3]) ** 2 + (
+      yv - disc_centers[1, 3]
+  ) ** 2 <= diameter**2 / 4
 
-    return rect_vert | rect_hori | disc0 | disc1 | disc2 | disc3
-
-
-def disc(resolution: float,
-         phys_size: Tuple[float, float],
-         diameter: float,
-         center: Tuple[float, float] = (0, 0)) -> np.ndarray:
-    """
-    Return a Boolean array where all True elements form a disc.
-
-    Args:
-        resolution: A float that represents the number of points per unit length.
-        phys_size: A tuple with two elements that describe the physical size of the entire pattern.
-        diameter: A float that represents the diameter of the disc.
-        center: A tuple with two elements that describe the coordinates of the center of the square.
-
-    Returns:
-        An array with Boolean elements. 
-    """
-
-    phys_size = np.array(phys_size)
-    grid_size = phys_size - 1 / resolution
-    n = np.round(phys_size * resolution).astype(int)
-
-    x_coord = np.linspace(-grid_size[0] / 2, grid_size[0] / 2, n[0])
-    y_coord = np.linspace(-grid_size[1] / 2, grid_size[1] / 2, n[1])
-    xv, yv = np.meshgrid(x_coord, y_coord, sparse=True, indexing='ij')
-
-    return (xv - center[0])**2 + (yv - center[1])**2 <= diameter**2 / 4
+  return rect_vert | rect_hori | disc0 | disc1 | disc2 | disc3
 
 
-def stripe(resolution: float,
-           phys_size: Tuple[float, float],
-           width,
-           center: Tuple[float, float] = (0, 0),
-           angle: float = 0) -> np.ndarray:
-    """
-    Return a Boolean array where all True elements form a disc.
+def disc(
+    resolution: float,
+    phys_size: Tuple[float, float],
+    diameter: float,
+    center: Tuple[float, float] = (0, 0),
+) -> np.ndarray:
+  """Return a Boolean array where all True elements form a disc.
 
-    Args:
-        resolution: A float that represents the number of points per unit length.
-        phys_size: A tuple with two elements that describe the physical size of the entire pattern.
-        width: A float that represents the width of the stripe.
-        center: A tuple with two elements that describe the coordinates of the center of the stripe.
-        angle: A float that represents the angle of rotation in degree.
+  Args:
+      resolution: A float that represents the number of points per unit length.
+      phys_size: A tuple with two elements that describe the physical size of
+        the entire pattern.
+      diameter: A float that represents the diameter of the disc.
+      center: A tuple with two elements that describe the coordinates of the
+        center of the square.
 
-    Returns:
-        An array with Boolean elements. 
-    """
+  Returns:
+      An array with Boolean elements.
+  """
 
-    phys_size = np.array(phys_size)
-    angle = np.radians(angle)
+  phys_size = np.array(phys_size)
+  grid_size = phys_size - 1 / resolution
+  n = np.round(phys_size * resolution).astype(int)
 
-    grid_size = phys_size - 1 / resolution
-    n = np.round(phys_size * resolution).astype(int)
+  x_coord = np.linspace(-grid_size[0] / 2, grid_size[0] / 2, n[0])
+  y_coord = np.linspace(-grid_size[1] / 2, grid_size[1] / 2, n[1])
+  xv, yv = np.meshgrid(x_coord, y_coord, sparse=True, indexing='ij')
 
-    x_coord = np.linspace(-grid_size[0] / 2, grid_size[0] / 2, n[0])
-    y_coord = np.linspace(-grid_size[1] / 2, grid_size[1] / 2, n[1])
-    xv, yv = np.meshgrid(x_coord, y_coord, sparse=True, indexing='ij')
+  return (xv - center[0]) ** 2 + (yv - center[1]) ** 2 <= diameter**2 / 4
 
-    return abs(
-        np.sin(angle) * (xv - center[0]) - np.cos(angle) *
-        (yv - center[1])) <= width / 2
+
+def stripe(
+    resolution: float,
+    phys_size: Tuple[float, float],
+    width,
+    center: Tuple[float, float] = (0, 0),
+    angle: float = 0,
+) -> np.ndarray:
+  """Return a Boolean array where all True elements form a disc.
+
+  Args:
+      resolution: A float that represents the number of points per unit length.
+      phys_size: A tuple with two elements that describe the physical size of
+        the entire pattern.
+      width: A float that represents the width of the stripe.
+      center: A tuple with two elements that describe the coordinates of the
+        center of the stripe.
+      angle: A float that represents the angle of rotation in degree.
+
+  Returns:
+      An array with Boolean elements.
+  """
+
+  phys_size = np.array(phys_size)
+  angle = np.radians(angle)
+
+  grid_size = phys_size - 1 / resolution
+  n = np.round(phys_size * resolution).astype(int)
+
+  x_coord = np.linspace(-grid_size[0] / 2, grid_size[0] / 2, n[0])
+  y_coord = np.linspace(-grid_size[1] / 2, grid_size[1] / 2, n[1])
+  xv, yv = np.meshgrid(x_coord, y_coord, sparse=True, indexing='ij')
+
+  return (
+      abs(np.sin(angle) * (xv - center[0]) - np.cos(angle) * (yv - center[1]))
+      <= width / 2
+  )

--- a/imageruler/test_imageruler.py
+++ b/imageruler/test_imageruler.py
@@ -1,10 +1,13 @@
+"""Tests for imageruler."""
+
 import unittest
-import numpy as np
 import imageruler
+import numpy as np
+
 try:
-    from imageruler.regular_shapes import disc, rounded_square, stripe
+  from imageruler.regular_shapes import disc, rounded_square, stripe
 except:
-    from regular_shapes import disc, rounded_square, stripe
+  from regular_shapes import disc, rounded_square, stripe
 
 
 # properties of design weights array
@@ -13,175 +16,164 @@ phys_size = (200, 200)
 
 
 class TestDuality(unittest.TestCase):
+  diameters = [2.2, 45.2, 50.1, 80.2, 101.5]
 
-    diameters = [2.2, 45.2, 50.1, 80.2, 101.5]
+  def duality_dilation_erosion(self, weights: np.ndarray, diam: float) -> bool:
+    """Checks the duality of the dilation and erosion operators for solid
 
-    def duality_dilation_erosion(self,  weights: np.ndarray,
-                                 diam: float) -> bool:
-        """
-        Checks the duality of the dilation and erosion operators for solid
-        and void features of the design weights.
+    and void features of the design weights.
 
-        Args:
-            weights: the design weights as a 2d array.
-            diam: the diameter of the circular-ball kernel.
+    Args:
+        weights: the design weights as a 2d array.
+        diam: the diameter of the circular-ball kernel.
 
-        Returns:
-            A Boolean indicating whether duality is satisfied or not.
-        """
-        erosion_of_negation = imageruler.binary_erode(~weights, diam)
-        negation_of_dilation = ~imageruler.binary_dilate(weights, diam)
-        dilation_of_negation = imageruler.binary_dilate(~weights, diam)
-        negation_of_erosion = ~imageruler.binary_erode(weights, diam)
-        return (erosion_of_negation == negation_of_dilation).all() and (
-            negation_of_erosion == dilation_of_negation).all()
+    Returns:
+        A Boolean indicating whether duality is satisfied or not.
+    """
+    erosion_of_negation = imageruler.binary_erode(~weights, diam)
+    negation_of_dilation = ~imageruler.binary_dilate(weights, diam)
+    dilation_of_negation = imageruler.binary_dilate(~weights, diam)
+    negation_of_erosion = ~imageruler.binary_erode(weights, diam)
+    return (erosion_of_negation == negation_of_dilation).all() and (
+        negation_of_erosion == dilation_of_negation
+    ).all()
 
+  def duality_closing_opening(self, weights: np.ndarray, diam: float) -> bool:
+    """Checks the duality of the opening and closing morphological transform
 
-    def duality_closing_opening(self, weights: np.ndarray,
-                                diam: float) -> bool:
-        """
-        Checks the duality of the opening and closing morphological transform
-        operators for solid and void features of the design weights.
+    operators for solid and void features of the design weights.
 
-        Args:
-            weights: the design weights as a 2d array.
-            diam: the diameter of the circular-ball kernel.
+    Args:
+        weights: the design weights as a 2d array.
+        diam: the diameter of the circular-ball kernel.
 
-        Returns:
-            A Boolean indicating whether duality is satisfied or not.
-        """
-        opening_of_negation = imageruler.binary_open(~weights, diam)
-        negation_of_closing = ~imageruler.binary_close(weights, diam)
-        closing_of_negation = imageruler.binary_close(~weights, diam)
-        negation_of_opening = ~imageruler.binary_open(weights, diam)
-        return (opening_of_negation == negation_of_closing).all() and (
-            closing_of_negation == negation_of_opening).all()
+    Returns:
+        A Boolean indicating whether duality is satisfied or not.
+    """
+    opening_of_negation = imageruler.binary_open(~weights, diam)
+    negation_of_closing = ~imageruler.binary_close(weights, diam)
+    closing_of_negation = imageruler.binary_close(~weights, diam)
+    negation_of_opening = ~imageruler.binary_open(weights, diam)
+    return (opening_of_negation == negation_of_closing).all() and (
+        closing_of_negation == negation_of_opening
+    ).all()
 
+  def test_rounded_square(self):
+    print("------ Testing duality property using rounded squares ------")
 
-    def test_rounded_square(self):
-        print("------ Testing duality property using rounded squares ------")
+    declared_mls: float = 50.0
+    for angle in [0, 10.5, 44.3, 73.9]:
+      print(f"Rotation angle of the rounded square: {angle}°")
+      pattern = rounded_square(resolution, phys_size, declared_mls, angle=angle)
+      for diameter in self.diameters:
+        print(f"Kernel diameter: {diameter:.2f}")
+        self.assertTrue(self.duality_dilation_erosion(pattern, diameter))
+        self.assertTrue(self.duality_closing_opening(pattern, diameter))
 
-        declared_mls: float = 50.0
-        for angle in [0, 10.5, 44.3, 73.9]:
-            print(f"Rotation angle of the rounded square: {angle}°")
-            pattern = rounded_square(resolution, phys_size, declared_mls,
-                                     angle=angle)
-            for diameter in self.diameters:
-                print(f"Kernel diameter: {diameter:.2f}")
-                self.assertTrue(
-                    self.duality_dilation_erosion(pattern, diameter)
-                )
-                self.assertTrue(
-                    self.duality_closing_opening(pattern, diameter)
-                )
+  def test_disc(self):
+    print("------ Testing duality property using a disc ------")
 
-    def test_disc(self):
-        print("------ Testing duality property using a disc ------")
+    diam = 50.0
+    pattern = disc(resolution, phys_size, diam)
+    for diameter in self.diameters:
+      print(f"Kernel diameter: {diameter:.2f}")
+      self.assertTrue(self.duality_dilation_erosion(pattern, diameter))
+      self.assertTrue(self.duality_closing_opening(pattern, diameter))
 
-        diam = 50.0
-        pattern = disc(resolution, phys_size, diam)
-        for diameter in self.diameters:
-            print(f"Kernel diameter: {diameter:.2f}")
-            self.assertTrue(
-                self.duality_dilation_erosion(pattern, diameter)
-            )
-            self.assertTrue(
-                self.duality_closing_opening(pattern, diameter)
-            )
+  def test_ring(self):
+    print("------ Testing duality property using concentric circles ------")
 
-    def test_ring(self):
-        print("------ Testing duality property using concentric circles ------")
+    outer_diameter, inner_diameter = 120, 50
+    declared_solid_mls, declared_void_mls = (
+        outer_diameter - inner_diameter
+    ) / 2, inner_diameter
+    print(
+        f"Declared minimum length scale: {declared_solid_mls:.2f} "
+        f"(solid), {declared_void_mls:.2f} (void)"
+    )
 
-        outer_diameter, inner_diameter = 120, 50
-        declared_solid_mls, declared_void_mls = (
-            outer_diameter - inner_diameter) / 2, inner_diameter
-        print(f"Declared minimum length scale: {declared_solid_mls:.2f} "
-              f"(solid), {declared_void_mls:.2f} (void)")
+    solid_disc = disc(resolution, phys_size, diameter=outer_diameter)
+    void_disc = disc(resolution, phys_size, diameter=inner_diameter)
+    pattern = solid_disc ^ void_disc  # ring
 
-        solid_disc = disc(resolution, phys_size, diameter=outer_diameter)
-        void_disc = disc(resolution, phys_size, diameter=inner_diameter)
-        pattern = solid_disc ^ void_disc  # ring
-
-        for diameter in self.diameters:
-            print(f"Kernel diameter: {diameter:.2f}")
-            self.assertTrue(
-                self.duality_dilation_erosion(pattern, diameter)
-            )
-            self.assertTrue(
-                self.duality_closing_opening(pattern, diameter)
-            )
+    for diameter in self.diameters:
+      print(f"Kernel diameter: {diameter:.2f}")
+      self.assertTrue(self.duality_dilation_erosion(pattern, diameter))
+      self.assertTrue(self.duality_closing_opening(pattern, diameter))
 
 
 class TestMinimumLengthScale(unittest.TestCase):
 
-    def test_rounded_square(self):
-        print("------ Testing minimum length scale of rounded squares ------")
+  def test_rounded_square(self):
+    print("------ Testing minimum length scale of rounded squares ------")
 
-        declared_mls = 50
-        print("Declared minimum length scale: ", declared_mls)
+    declared_mls = 50
+    print("Declared minimum length scale: ", declared_mls)
 
-        for angle in [5.6, 25.2, 49.3, 69.5]:
-            pattern = rounded_square(resolution,
-                                     phys_size,
-                                     declared_mls,
-                                     angle=angle)
-            solid_mls = imageruler.minimum_length_solid(pattern)
-            print(f"Rotation angle of the rounded square: {angle}°")
-            print(f"Estimated minimum length scale: {solid_mls:.2f}")
-            self.assertAlmostEqual(solid_mls, declared_mls, delta=4)
+    for angle in [5.6, 25.2, 49.3, 69.5]:
+      pattern = rounded_square(resolution, phys_size, declared_mls, angle=angle)
+      solid_mls = imageruler.minimum_length_solid(pattern)
+      print(f"Rotation angle of the rounded square: {angle}°")
+      print(f"Estimated minimum length scale: {solid_mls:.2f}")
+      self.assertAlmostEqual(solid_mls, declared_mls, delta=4)
 
-    def test_disc(self):
-        print("------ Testing minimum length scale of a disc ------")
+  def test_disc(self):
+    print("------ Testing minimum length scale of a disc ------")
 
-        diameter = 50
-        print(f"Declared minimum length scale: {diameter}")
-        pattern = disc(resolution, phys_size, diameter)
-        solid_mls = imageruler.minimum_length_solid(pattern, phys_size)
-        print(f"Estimated minimum length scale: {solid_mls:.2f}")
-        self.assertAlmostEqual(solid_mls, diameter, delta=1)
+    diameter = 50
+    print(f"Declared minimum length scale: {diameter}")
+    pattern = disc(resolution, phys_size, diameter)
+    solid_mls = imageruler.minimum_length_solid(pattern, phys_size)
+    print(f"Estimated minimum length scale: {solid_mls:.2f}")
+    self.assertAlmostEqual(solid_mls, diameter, delta=1)
 
-    def test_ring(self):
-        print(
-            "------ Testing minimum length scale of concentric circles ------")
+  def test_ring(self):
+    print("------ Testing minimum length scale of concentric circles ------")
 
-        outer_diameter, inner_diameter = 120, 50
-        declared_solid_mls, declared_void_mls = (
-            outer_diameter - inner_diameter) / 2, inner_diameter
-        print(f"Declared minimum length scale: {declared_solid_mls:.2f} "
-              f"(solid), {declared_void_mls:.2f} (void)")
+    outer_diameter, inner_diameter = 120, 50
+    declared_solid_mls, declared_void_mls = (
+        outer_diameter - inner_diameter
+    ) / 2, inner_diameter
+    print(
+        f"Declared minimum length scale: {declared_solid_mls:.2f} "
+        f"(solid), {declared_void_mls:.2f} (void)"
+    )
 
-        solid_disc = disc(resolution, phys_size, diameter=outer_diameter)
-        void_disc = disc(resolution, phys_size, diameter=inner_diameter)
-        pattern = solid_disc ^ void_disc  # ring
+    solid_disc = disc(resolution, phys_size, diameter=outer_diameter)
+    void_disc = disc(resolution, phys_size, diameter=inner_diameter)
+    pattern = solid_disc ^ void_disc  # ring
 
-        solid_mls = imageruler.minimum_length_solid(pattern)
-        void_mls = imageruler.minimum_length_void(pattern)
-        dual_mls = imageruler.minimum_length(pattern)
-        print(f"Estimated minimum length scale: {solid_mls:.2f} (solid), ",
-              f"{void_mls:.2f} (void)")
+    solid_mls = imageruler.minimum_length_solid(pattern)
+    void_mls = imageruler.minimum_length_void(pattern)
+    dual_mls = imageruler.minimum_length(pattern)
+    print(
+        f"Estimated minimum length scale: {solid_mls:.2f} (solid), ",
+        f"{void_mls:.2f} (void)",
+    )
 
-        self.assertAlmostEqual(solid_mls, declared_solid_mls, delta=1)
-        self.assertAlmostEqual(void_mls, declared_void_mls, delta=1)
-        self.assertAlmostEqual(dual_mls,
-                               min(declared_solid_mls, declared_void_mls),
-                               delta=1)
-        self.assertEqual(dual_mls, min(solid_mls, void_mls))
+    self.assertAlmostEqual(solid_mls, declared_solid_mls, delta=1)
+    self.assertAlmostEqual(void_mls, declared_void_mls, delta=1)
+    self.assertAlmostEqual(
+        dual_mls, min(declared_solid_mls, declared_void_mls), delta=1
+    )
+    self.assertEqual(dual_mls, min(solid_mls, void_mls))
 
-    def test_periodicity(self):
-        print("------ Testing minimum length scale on a periodic image ------")
+  def test_periodicity(self):
+    print("------ Testing minimum length scale on a periodic image ------")
 
-        stripe_width = 50
-        print(f"Declared minimum length scale: {stripe_width}")
-        pattern = stripe(
-            resolution, phys_size, stripe_width, center=(0, -phys_size[1] / 2)
-        ) | stripe(
-            resolution, phys_size, stripe_width, center=(0, phys_size[1] / 2))
-        solid_mls = imageruler.minimum_length_solid(pattern,
-                                                    phys_size,
-                                                    periodic_axes=1)
-        print(f"Estimated minimum length scale: {solid_mls:.2f}")
-        self.assertAlmostEqual(solid_mls, stripe_width, delta=1)
+    stripe_width = 50
+    print(f"Declared minimum length scale: {stripe_width}")
+    pattern = stripe(
+        resolution, phys_size, stripe_width, center=(0, -phys_size[1] / 2)
+    ) | stripe(
+        resolution, phys_size, stripe_width, center=(0, phys_size[1] / 2)
+    )
+    solid_mls = imageruler.minimum_length_solid(
+        pattern, phys_size, periodic_axes=1
+    )
+    print(f"Estimated minimum length scale: {solid_mls:.2f}")
+    self.assertAlmostEqual(solid_mls, stripe_width, delta=1)
 
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()


### PR DESCRIPTION
This PR is a first step at cleaning up the imageruler codebase. Summary of changes:

- Apply common formatting to the primary modules
- Add missing type hints and fix inconsistencies
- Clean up docstrings
- Remove unecessary docstrings on private functions
- Add a padding mode enum

Overall, this is just a starting point. There is still a lot of ambiguity in some of the docstrings around default values and expected behaviors, e.g. what happens when `phys_size` is not specified