### PR TITLE
Additional cleanup and add option for selecting kernel shape

### DIFF
--- a/imageruler/__init__.py
+++ b/imageruler/__init__.py
@@ -5,11 +5,13 @@ __version__ = '1.0'
 import imageruler.imageruler
 import imageruler.regular_shapes
 from .imageruler import (
+    KernelShape,
     PaddingMode,
     binary_close,
     binary_dilate,
     binary_erode,
     binary_open,
+    get_kernel,
     length_violation,
     length_violation_solid,
     length_violation_void,

--- a/imageruler/imageruler.py
+++ b/imageruler/imageruler.py
@@ -11,10 +11,28 @@ warnings.simplefilter('always')
 # Threshold used for binarization.
 _BINARIZATION_THRESHOLD = 0.5
 
+_PLUS_KERNEL = np.array(
+    [
+        [0, 1, 0],
+        [1, 1, 1],
+        [0, 1, 0],
+    ],
+    dtype=np.uint8,
+)
+
+Array = np.ndarray
 PhysicalSize = Tuple[float, ...]
 PixelSize = Tuple[float, ...]
 MarginSize = Tuple[Tuple[float, float], ...]
 PeriodicAxes = Tuple[int, ...]
+Padding = Tuple[Tuple[int, int], Tuple[int, int]]
+
+
+@enum.unique
+class Direction(enum.Enum):
+  IN = 'in'
+  OUT = 'out'
+  BOTH = 'both'
 
 
 @enum.unique
@@ -24,34 +42,46 @@ class PaddingMode(enum.Enum):
   VOID = 'void'
 
 
+@enum.unique
+class KernelShape(enum.Enum):
+  CIRCLE = 'circle'
+  RECTANGLE = 'rectangle'
+
+
 def minimum_length_solid(
-    array: np.ndarray,
+    array: Array,
     phys_size: Optional[PhysicalSize] = None,
     periodic_axes: Optional[PeriodicAxes] = None,
     margin_size: Optional[MarginSize] = None,
     pad_mode: PaddingMode = PaddingMode.SOLID,
+    kernel_shape: KernelShape = KernelShape.CIRCLE,
     warn_cusp: bool = False,
 ) -> float:
   """Computes the minimum length scale of the solid regions of an image.
 
   Args:
-    array: The image as a 1d or 2d array.
-    phys_size: The physical dimensions of the image. Default is None.
-    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
-      None.
+    array: The 1D or 2D binarized image array.
+    phys_size: The extent of the image in physical units. If not specified,
+      pixel units are used for the returned length scale.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. If not
+      specified, no axes are treated as periodic.
     margin_size: The physical dimensions of the image margins. If specified,
-      this subregion is excluded from the result. Default is None.
-    pad_mode: The padding mode, defaults to solid.
+      this subregion is excluded from the length scale measurement. Default is
+      no margins.
+    pad_mode: The padding mode to use at the image boundaries. Defaults to
+      solid.
+    kernel_shape: The kernel shape to use for probing the length scale. Defaults
+      to a circular kernel.
     warn_cusp: Whether to warn about the presence of sharp corners or cusps
       detected in the image. Default is False (no warning).
 
   Returns:
-    The minimum length scale of the solid regions. The units are the same
-    as `phys_size`. If `phys_size` is None, the units are in number of
-    pixels.
+    The minimum length scale of the solid regions in the input image. The units
+    are the same as those of `phys_size`. If `phys_size` is not specified, pixel
+    units are used.
   """
 
-  array, pixel_size, short_pixel_side, short_entire_side = _ruler_initialize(
+  array, pixel_size, short_pixel_side, short_entire_side = _initialize_ruler(
       array, phys_size, periodic_axes, warn_cusp
   )
 
@@ -63,14 +93,19 @@ def minimum_length_solid(
 
   if array.ndim == 1:
     if margin_size is not None:
-      array = _trim(array, margin_size, pixel_size)
+      array = _trim_margins(array, margin_size, pixel_size)
     solid_min_length, _ = _minimum_length_1d(array)
     return solid_min_length * short_pixel_side
 
-  def _interior_pixel_number(diameter: float, array: np.ndarray) -> bool:
+  def _interior_pixel_number(diameter: float, array: Array) -> bool:
     """Determines whether an image violates a given length scale."""
     return _length_violation_solid(
-        array, diameter, pixel_size, margin_size, pad_mode
+        array=array,
+        diameter=diameter,
+        pixel_size=pixel_size,
+        margin_size=margin_size,
+        pad_mode=pad_mode,
+        kernel_shape=kernel_shape,
     ).any()
 
   min_len, _ = _search(
@@ -83,32 +118,37 @@ def minimum_length_solid(
 
 
 def minimum_length_void(
-    array: np.ndarray,
+    array: Array,
     phys_size: Optional[PhysicalSize] = None,
     periodic_axes: Optional[PeriodicAxes] = None,
     margin_size: Optional[MarginSize] = None,
     pad_mode: PaddingMode = PaddingMode.VOID,
+    kernel_shape: KernelShape = KernelShape.CIRCLE,
     warn_cusp: bool = False,
 ) -> float:
-  """Computes the minimum length scale of the void regions in an image.
+  """Computes the minimum length scale of the void regions of an image.
 
   Args:
-    array: The image as a 1d or 2d array.
-    phys_size: The physical dimensions of the image. Default is None.
-    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
-      None.
+    array: The 1D or 2D binarized image array.
+    phys_size: The extent of the image in physical units. If not specified,
+      pixel units are used for the returned length scale.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. If not
+      specified, no axes are treated as periodic.
     margin_size: The physical dimensions of the image margins. If specified,
-      this subregion is excluded from the result. Default is None.
-    pad_mode: The padding mode, defaults to void.
+      this subregion is excluded from the length scale measurement. Default is
+      no margins.
+    pad_mode: The padding mode to use at the image boundaries. Defaults to void.
+    kernel_shape: The kernel shape to use for probing the length scale. Defaults
+      to a circular kernel.
     warn_cusp: Whether to warn about the presence of sharp corners or cusps
       detected in the image. Default is False (no warning).
 
   Returns:
-    The minimum length scale of the void regions. The units are the same
-    as `phys_size`. If `phys_size` is None, the units are in number of
-    pixels.
+    The minimum length scale of the void regions in the input image. The units
+    are the same as those of `phys_size`. If `phys_size` is not specified, pixel
+    units are used.
   """
-  array, _, _, _ = _ruler_initialize(array, phys_size)
+  array, _, _, _ = _initialize_ruler(array, phys_size)
   if pad_mode is PaddingMode.SOLID:
     pad_mode = PaddingMode.VOID
   elif pad_mode is PaddingMode.VOID:
@@ -117,12 +157,18 @@ def minimum_length_void(
     pad_mode = PaddingMode.EDGE
 
   return minimum_length_solid(
-      ~array, phys_size, periodic_axes, margin_size, pad_mode, warn_cusp
+      array=~array,
+      phys_size=phys_size,
+      periodic_axes=periodic_axes,
+      margin_size=margin_size,
+      pad_mode=pad_mode,
+      kernel_shape=kernel_shape,
+      warn_cusp=warn_cusp,
   )
 
 
 def minimum_length_solid_void(
-    array: np.ndarray,
+    array: Array,
     phys_size: Optional[PhysicalSize] = None,
     periodic_axes: Optional[PeriodicAxes] = None,
     margin_size: Optional[MarginSize] = None,
@@ -130,36 +176,53 @@ def minimum_length_solid_void(
         PaddingMode.SOLID,
         PaddingMode.VOID,
     ),
+    kernel_shape: KernelShape = KernelShape.CIRCLE,
     warn_cusp: bool = False,
 ) -> Tuple[float, float]:
-  """Computes the minimum length scale of an image.
+  """Computes the minimum length scale for both phases of an image.
 
   Args:
-    array: The image as a 1d or 2d array.
-    phys_size: The physical dimensions of the image. Default is None.
-    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
-      None.
+    array: The 1D or 2D binarized image array.
+    phys_size: The extent of the image in physical units. If not specified,
+      pixel units are used for the returned length scale.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. If not
+      specified, no axes are treated as periodic.
     margin_size: The physical dimensions of the image margins. If specified,
-      this subregion is excluded from the result. Default is None.
-    pad_mode: The padding mode to apply to the solid and void phases.
-    warn_cusp: A boolean value that specifies whether to warn about sharp
-      corners or cusps. If True, a warning will be given when arr is likely to
-      contain sharp corners or cusps. Default is False (no warning).
+      this subregion is excluded from the length scale measurement. Default is
+      no margins.
+    pad_mode: The padding mode to use at the image boundaries for each phase.
+      Defaults to solid for the solid phase and void for the void phase.
+    kernel_shape: The kernel shape to use for probing the length scale. Defaults
+      to a circular kernel.
+    warn_cusp: Whether to warn about the presence of sharp corners or cusps
+      detected in the image. Default is False (no warning).
 
   Returns:
-    The minimum length scale of the solid and void regions in the same unit
-    as `phys_size`. If `phys_size` is None, the units are in number of
-    pixels.
+    The minimum length scale of the solid and void phases in the input image.
+    The units are the same as those of `phys_size`. If `phys_size` is not
+    specified, pixel units are used.
   """
   return minimum_length_solid(
-      array, phys_size, periodic_axes, margin_size, pad_mode[0], warn_cusp
+      array=array,
+      phys_size=phys_size,
+      periodic_axes=periodic_axes,
+      margin_size=margin_size,
+      pad_mode=pad_mode[0],
+      kernel_shape=kernel_shape,
+      warn_cusp=warn_cusp,
   ), minimum_length_void(
-      array, phys_size, periodic_axes, margin_size, pad_mode[1]
+      array=array,
+      phys_size=phys_size,
+      periodic_axes=periodic_axes,
+      margin_size=margin_size,
+      pad_mode=pad_mode[1],
+      kernel_shape=kernel_shape,
+      warn_cusp=warn_cusp,
   )
 
 
 def minimum_length(
-    array: np.ndarray,
+    array: Array,
     phys_size: Optional[PhysicalSize] = None,
     periodic_axes: Optional[PeriodicAxes] = None,
     margin_size: Optional[MarginSize] = None,
@@ -167,33 +230,38 @@ def minimum_length(
         PaddingMode.SOLID,
         PaddingMode.VOID,
     ),
+    kernel_shape: KernelShape = KernelShape.CIRCLE,
     warn_cusp: bool = False,
 ) -> float:
   """Computes the minimum length scale of an image.
 
-  This is the smaller of the minimum length scale of the solid and void
-  regions. For a 2d image, this is computed using the difference between
+  Th returned value is the smaller of the minimum length scale of the solid and
+  void regions. For a 2D image, this is computed using the difference between
   morphological opening and closing. For a 1d image, this is computed using
   a brute-force search.
 
   Args:
-    array: The image as a 1d or 2d array.
-    phys_size: The physical dimensions of the image. Default is None.
-    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
-      None.
+    array: The 1D or 2D binarized image array.
+    phys_size: The extent of the image in physical units. If not specified,
+      pixel units are used for the returned length scale.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. If not
+      specified, no axes are treated as periodic.
     margin_size: The physical dimensions of the image margins. If specified,
-      this subregion is excluded from the result. Default is None.
-    pad_mode: The padding mode to apply to the solid and void phases.
-    warn_cusp: A boolean value that specifies whether to warn about sharp
-      corners or cusps. If True, a warning will be given when arr is likely to
-      contain sharp corners or cusps. Default is no warning (False).
+      this subregion is excluded from the length scale measurement. Default is
+      no margins.
+    pad_mode: The padding mode to use at the image boundaries for each phase.
+      Defaults to solid for the solid phase and void for the void phase.
+    kernel_shape: The kernel shape to use for probing the length scale. Defaults
+      to a circular kernel.
+    warn_cusp: Whether to warn about the presence of sharp corners or cusps
+      detected in the image. Default is False (no warning).
 
   Returns:
-    The minimum length scale of the solid and void regions in the same unit
-    as `phys_size`. If `phys_size` is None, the units are in number of
-    pixels.
+    The minimum length scale of the solid and void phases in the input image.
+    The units are the same as those of `phys_size`. If `phys_size` is not
+    specified, pixel units are used.
   """
-  array, pixel_size, short_pixel_side, short_entire_side = _ruler_initialize(
+  array, pixel_size, short_pixel_side, short_entire_side = _initialize_ruler(
       array, phys_size, periodic_axes, warn_cusp
   )
 
@@ -205,17 +273,22 @@ def minimum_length(
 
   if array.ndim == 1:
     if margin_size is not None:
-      array = _trim(array, margin_size, pixel_size)
+      array = _trim_margins(array, margin_size, pixel_size)
     solid_min_length, void_min_length = _minimum_length_1d(array)
     return min(solid_min_length, void_min_length) * short_pixel_side
 
   if isinstance(pad_mode, PaddingMode):
     pad_mode = (pad_mode, pad_mode)
 
-  def _interior_pixel_number(diameter: float, arr: np.ndarray) -> bool:
+  def _interior_pixel_number(diameter: float, arr: Array) -> bool:
     """Determines whether an image violates a given length scale."""
     return _length_violation(
-        arr, diameter, pixel_size, margin_size, pad_mode
+        array=arr,
+        diameter=diameter,
+        pixel_size=pixel_size,
+        margin_size=margin_size,
+        pad_mode=pad_mode,
+        kernel_shape=kernel_shape,
     ).any()
 
   min_len, _ = _search(
@@ -228,24 +301,25 @@ def minimum_length(
 
 
 def _length_violation_solid(
-    array: np.ndarray,
+    array: Array,
     diameter: float,
     pixel_size: PixelSize,
     margin_size: Optional[Tuple[Tuple[float, float], ...]] = None,
     pad_mode: PaddingMode = PaddingMode.SOLID,
-) -> np.ndarray:
+    kernel_shape: KernelShape = KernelShape.CIRCLE,
+) -> Array:
   """Identifies the solid subregions which contain length scale violations."""
-
-  open_diff = binary_open(array, diameter, pixel_size, pad_mode) ^ array
-  interior_diff = open_diff & _get_interior(array, 'in', pad_mode)
+  kernel = get_kernel(diameter, pixel_size, kernel_shape)
+  open_diff = binary_open(array, kernel, pad_mode) ^ array
+  interior_diff = open_diff & _get_interior(array, Direction.IN, pad_mode)
   if margin_size is not None:
-    interior_diff = _trim(interior_diff, margin_size, pixel_size)
+    interior_diff = _trim_margins(interior_diff, margin_size, pixel_size)
 
   return interior_diff
 
 
 def _length_violation(
-    array: np.ndarray,
+    array: Array,
     diameter: float,
     pixel_size: PixelSize,
     margin_size: Optional[MarginSize] = None,
@@ -253,78 +327,92 @@ def _length_violation(
         PaddingMode.SOLID,
         PaddingMode.VOID,
     ),
-) -> np.ndarray:
+    kernel_shape: KernelShape = KernelShape.CIRCLE,
+) -> Array:
   """Identifies the subregions which contain length scale violations."""
-
-  close_open_diff = binary_open(
-      array, diameter, pixel_size, pad_mode[0]
-  ) ^ binary_close(array, diameter, pixel_size, pad_mode[1])
-  interior_diff = close_open_diff & _get_interior(array, 'both', pad_mode)
+  kernel = get_kernel(diameter, pixel_size, kernel_shape)
+  close_open_diff = binary_open(array, kernel, pad_mode[0]) ^ binary_close(
+      array, kernel, pad_mode[1]
+  )
+  interior_diff = close_open_diff & _get_interior(
+      array, Direction.BOTH, pad_mode
+  )
   if margin_size is not None:
-    interior_diff = _trim(interior_diff, margin_size, pixel_size)
-
+    interior_diff = _trim_margins(interior_diff, margin_size, pixel_size)
   return interior_diff
 
 
 def length_violation_solid(
-    array: np.ndarray,
+    array: Array,
     diameter: float,
     phys_size: Optional[PhysicalSize] = None,
     periodic_axes: Optional[PeriodicAxes] = None,
     margin_size: Optional[MarginSize] = None,
     pad_mode: PaddingMode = PaddingMode.SOLID,
-) -> np.ndarray:
+    kernel_shape: KernelShape = KernelShape.CIRCLE,
+) -> Array:
   """Identifies the solid subregions which contain length scale violations.
 
   Args:
-    array: The image as a 2d array.
-    diameter: The diameter of the kernel (or "probe").
-    phys_size: The physical dimensions of the image. Default is None.
-    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
-      None.
+    array: The 2D binarized image array.
+    diameter: The diameter of the kernel for detecting length scale violations.
+    phys_size: The extent of the image in physical units. If not specified,
+      pixel units are used for the returned length scale.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. If not
+      specified, no axes are treated as periodic.
     margin_size: The physical dimensions of the image margins. If specified,
-      this subregion is excluded from the result. Default is None.
-    pad_mode: The padding mode, defaults to solid.
+      this subregion is excluded from the length scale measurement. Default is
+      no margins.
+    pad_mode: The padding mode to use at the image boundaries. Defaults to void.
+    kernel_shape: The kernel shape to use for probing the length scale. Defaults
+      to a circular kernel.
 
   Returns:
-      A 2d array of the violations. The array dimensions are the same as the
-      original image.
+    An array indicating the solid length scale violations in the input image.
   """
 
-  array, pixel_size, _, _ = _ruler_initialize(array, phys_size, periodic_axes)
+  array, pixel_size, _, _ = _initialize_ruler(array, phys_size, periodic_axes)
   assert array.ndim == 2
   return _length_violation_solid(
-      array, diameter, pixel_size, margin_size, pad_mode
+      array=array,
+      diameter=diameter,
+      pixel_size=pixel_size,
+      margin_size=margin_size,
+      pad_mode=pad_mode,
+      kernel_shape=kernel_shape,
   )
 
 
 def length_violation_void(
-    array: np.ndarray,
+    array: Array,
     diameter: float,
     phys_size: Optional[PhysicalSize] = None,
     periodic_axes: Optional[PeriodicAxes] = None,
     margin_size: Optional[MarginSize] = None,
     pad_mode: str = 'void',
-) -> np.ndarray:
+    kernel_shape: KernelShape = KernelShape.CIRCLE,
+) -> Array:
   """Identifies the void subregions which contain length scale violations.
 
   Args:
-    array: The image as a 2d array.
-    diameter: The diameter of the kernel (or "probe").
-    phys_size: The physical dimensions of the image. Default is None.
-    periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
-      None.
+    array: The 2D binarized image array.
+    diameter: The diameter of the kernel for detecting length scale violations.
+    phys_size: The extent of the image in physical units. If not specified,
+      pixel units are used for the returned length scale.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. If not
+      specified, no axes are treated as periodic.
     margin_size: The physical dimensions of the image margins. If specified,
-      this subregion is excluded from the result. Default is None.
-    pad_mode: A string that represents the padding mode, which can be 'solid',
-      'void', or 'edge'. Default is 'solid'.
+      this subregion is excluded from the length scale measurement. Default is
+      no margins.
+    pad_mode: The padding mode to use at the image boundaries. Defaults to void.
+    kernel_shape: The kernel shape to use for probing the length scale. Defaults
+      to a circular kernel.
 
   Returns:
-      A 2d array of the violations. The array dimensions are the same as the
-      original image.
+    An array indicating the void length scale violations in the input image.
   """
 
-  array, pixel_size, _, _ = _ruler_initialize(array, phys_size, periodic_axes)
+  array, pixel_size, _, _ = _initialize_ruler(array, phys_size, periodic_axes)
   assert array.ndim == 2
 
   if pad_mode is PaddingMode.SOLID:
@@ -335,12 +423,17 @@ def length_violation_void(
     pad_mode = PaddingMode.EDGE
 
   return _length_violation_solid(
-      ~array, diameter, pixel_size, margin_size, pad_mode
+      array=~array,
+      diameter=diameter,
+      pixel_size=pixel_size,
+      margin_size=margin_size,
+      pad_mode=pad_mode,
+      kernel_shape=kernel_shape,
   )
 
 
 def length_violation(
-    array: np.ndarray,
+    array: Array,
     diameter: float,
     phys_size: Optional[PhysicalSize] = None,
     periodic_axes: Optional[PeriodicAxes] = None,
@@ -349,70 +442,80 @@ def length_violation(
         PaddingMode.SOLID,
         PaddingMode.VOID,
     ),
-) -> np.ndarray:
+    kernel_shape: KernelShape = KernelShape.CIRCLE,
+) -> Array:
   """Identifies the subregions which contain length scale violations.
 
   Args:
-      array: The image as a 2d array.
-      diameter: The diameter of the kernel (or "probe").
-      phys_size: The physical dimensions of the image. Default is None.
-      periodic_axes: The axes which are periodic. x is 0 and y is 1. Default is
-        None.
-      margin_size: The physical dimensions of the image margins. If specified,
-        this subregion is excluded from the result. Default is None.
-      pad_mode: The padding mode, defaults to solid.
+    array: The 2D binarized image array.
+    diameter: The diameter of the kernel for detecting length scale violations.
+    phys_size: The extent of the image in physical units. If not specified,
+      pixel units are used for the returned length scale.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. If not
+      specified, no axes are treated as periodic.
+    margin_size: The physical dimensions of the image margins. If specified,
+      this subregion is excluded from the length scale measurement. Default is
+      no margins.
+    pad_mode: The padding mode to use at the image boundaries for each phase.
+      Defaults to solid for the solid phase and void for the void phase.
+    kernel_shape: The kernel shape to use for probing the length scale. Defaults
+      to a circular kernel.
 
   Returns:
-      A 2d array of the violations. The array dimensions are the same as the
-      original image.
+    An array indicating the length scale violations in the input image.
   """
 
-  array, pixel_size, _, _ = _ruler_initialize(array, phys_size, periodic_axes)
+  array, pixel_size, _, _ = _initialize_ruler(array, phys_size, periodic_axes)
   assert array.ndim == 2
-  if isinstance(pad_mode, str):
+  if isinstance(pad_mode, PaddingMode):
     pad_mode = (pad_mode, pad_mode)
 
-  return _length_violation(array, diameter, pixel_size, margin_size, pad_mode)
+  return _length_violation(
+      array=array,
+      diameter=diameter,
+      pixel_size=pixel_size,
+      margin_size=margin_size,
+      pad_mode=pad_mode,
+      kernel_shape=kernel_shape,
+  )
 
 
-def _ruler_initialize(
-    array: np.ndarray,
+def _initialize_ruler(
+    array: Array,
     phys_size: PhysicalSize,
     periodic_axes: Optional[PeriodicAxes] = None,
     warn_cusp: bool = False,
-) -> Tuple[np.ndarray, PixelSize, float, float]:
+) -> Tuple[Array, PixelSize, float, float]:
   """Initializes the ruler.
 
   This function converts the input array to a boolean array without redundant
   dimensions and computes some basic information about the image.
 
   Args:
-      array: An array that represents an image.
-      phys_size: A tuple, list, array, or number that represents the physical
-        size of the image.
-      periodic_axes: A tuple of axes (x, y = 0, 1) treated as periodic (default
-        is None: all axes are non-periodic).
-      warn_cusp: A boolean value that determines whether to warn about sharp
-        corners or cusps. If True, warning will be given when the input 2d image
-        is likely to contain sharp corners or cusps; if False, warning will not
-        be given.
+    array: The 2D binarized image array.
+    phys_size: The extent of the image in physical units. If not specified,
+      pixel units are used for the returned length scale.
+    periodic_axes: The axes which are periodic. x is 0 and y is 1. If not
+      specified, no axes are treated as periodic.
+    warn_cusp: Whether to warn about the presence of sharp corners or cusps
+      detected in the image. Default is False (no warning).
 
   Returns:
-      A tuple with four elements. The first is a Boolean array obtained by
-      squeezing and binarizing the input array, the second is an array that
-      contains the pixel size, the third is the length of the shorter side of
-      the pixel, and the fourth is the length of the shorter side of the image.
+    A tuple with four elements. The first is a Boolean array obtained by
+    squeezing and binarizing the input array, the second is an array that
+    contains the pixel size, the third is the length of the shorter side of
+    the pixel, and the fourth is the length of the shorter side of the image.
 
   Raises:
-      ValueError: If the physical size `phys_size` does not have the
-      expected format or the length of `phys_size` does not match the dimension
-      of the input array.
+    ValueError: If the physical size `phys_size` does not have the
+    expected format or the length of `phys_size` does not match the dimension
+    of the input array.
   """
 
   array = np.squeeze(array)
 
   if (
-      isinstance(phys_size, np.ndarray)
+      isinstance(phys_size, Array)
       or isinstance(phys_size, list)
       or isinstance(phys_size, tuple)
   ):
@@ -466,24 +569,24 @@ def _search(
     arg_threshold: float,
     function: Callable[[float], bool],
 ) -> Tuple[float, bool]:
-  """Binary search.
+  """Performs a binary search.
 
   Args:
-      arg_range: Initial range of the argument under search.
-      arg_threshold: Threshold of the argument range, below which the search
-        stops.
-      function: A function that returns True if the viariable is large enough
-        but False if the variable is not large enough.
+    arg_range: Initial range of the argument under search.
+    arg_threshold: Threshold of the argument range, below which the search
+      stops.
+    function: A function that returns True if the viariable is large enough but
+      False if the variable is not large enough.
 
   Returns:
-      A tuple with two elements. The first is a float that represents the search
-      result. The second is a Boolean value, which is True if the search indeed
-      happens, False if the condition for starting search is not satisfied in
-      the beginning.
+    A tuple with two elements. The first is a float that represents the search
+    result. The second is a Boolean value, which is True if the search indeed
+    happens, False if the condition for starting search is not satisfied in
+    the beginning.
 
   Raises:
-      RuntimeError: If `function` returns True at a smaller input viariable
-      but False at a larger input viariable.
+    RuntimeError: If `function` returns True at a smaller input viariable
+    but False at a larger input viariable.
   """
 
   args = [min(arg_range), (min(arg_range) + max(arg_range)) / 2, max(arg_range)]
@@ -509,11 +612,11 @@ def _search(
     raise RuntimeError('The function is not monotonically increasing.')
 
 
-def _minimum_length_1d(array: np.ndarray) -> Tuple[int, int]:
-  """Search the minimum lengths of solid and void segments in a 1d array.
+def _minimum_length_1d(array: Array) -> Tuple[int, int]:
+  """Searches the minimum lengths of solid and void segments in a 1d array.
 
   Args:
-    array: A 1d Boolean array.
+    array: A 1D boolean array.
 
   Returns:
     A tuple of two integers. The first and second intergers represent the
@@ -548,234 +651,190 @@ def _minimum_length_1d(array: np.ndarray) -> Tuple[int, int]:
 
 
 def _get_interior(
-    array: np.ndarray,
-    direction: str,
+    array: Array,
+    direction: Direction,
     pad_mode: Union[PaddingMode, Tuple[PaddingMode, PaddingMode]],
-):
+) -> Array:
   """Gets inner borders, outer borders, or union of inner and outer borders.
 
   Args:
-    array: A 2d array that represents an image.
-    direction: A string that can be "in", "out", or "both" to indicate inner
-      borders, outer borders, and union of inner and outer borders.
+    array: A 2D array that represents an image.
+    direction: The direction indicating inner borders, outer borders, or a union
+      of inner and outer borders.
     pad_mode: The padding mode to use.
 
   Returns:
-      A Boolean array in which all True elements are at and only at borders.
-
-  Raises:
-      ValueError: If the option provided to `direction` is not 'in', 'out',
-      or 'both'.
+    A Boolean array in which all True elements are at and only at borders.
   """
-
-  pixel_size = (1,) * array.ndim
-  # With this pixel size and diameter, the resulting kernel has the shape of a
-  # plus sign.
-  diameter = 2.8
-
-  if direction == 'in':  # interior of solid regions
-    return binary_erode(array, diameter, pixel_size, pad_mode)
-  elif direction == 'out':  # interior of void regions
-    return ~binary_dilate(array, diameter, pixel_size, pad_mode)
-  elif direction == 'both':  # union of interiors of solid and void regions
-    eroded = binary_erode(array, diameter, pixel_size, pad_mode[0])
-    dilated = binary_dilate(array, diameter, pixel_size, pad_mode[1])
+  if direction is Direction.IN:
+    return binary_erode(array, _PLUS_KERNEL, pad_mode)
+  elif direction is Direction.OUT:
+    return ~binary_dilate(array, _PLUS_KERNEL, pad_mode)
+  elif direction is Direction.BOTH:
+    eroded = binary_erode(array, _PLUS_KERNEL, pad_mode[0])
+    dilated = binary_dilate(array, _PLUS_KERNEL, pad_mode[1])
     return ~dilated | eroded
   else:
-    raise ValueError(
-        'The direction at the border can only be in, out, or both.'
-    )
+    raise ValueError(f'Unknown direction: {direction.name}.')
 
 
-def _get_pixel_size(array: np.ndarray, phys_size: PhysicalSize) -> PixelSize:
-  """Compute the physical size of a single pixel.
-
-  Args:
-      array: An array that represents an image.
-      phys_size: A tuple that represents the physical size of the image.
-
-  Returns:
-      An array of floats. It represents the physical size of a single pixel.
-  """
+def _get_pixel_size(array: Array, phys_size: PhysicalSize) -> PixelSize:
+  """Gets the pixel size from an array and physical size."""
   return tuple(p / s for p, s in zip(phys_size, array.shape))
 
 
-def _binarize(array: np.ndarray) -> np.ndarray:
-  """Binarize the input array according to the threshold.
-
-  Args:
-      array: An array that represents an image.
-
-  Returns:
-      An Boolean array.
-  """
+def _binarize(array: Array) -> Array:
+  """Binarizes the input array."""
 
   return array > _BINARIZATION_THRESHOLD * max(array.flatten()) + (
       1 - _BINARIZATION_THRESHOLD
   ) * min(array.flatten())
 
 
-def _get_kernel(diameter: float, pixel_size: PixelSize) -> np.ndarray:
-  """Get the kernel with a given diameter and pixel size.
+def get_kernel(
+    diameter: float,
+    pixel_size: PixelSize = (1.0, 1.0),
+    kernel_shape: KernelShape = KernelShape.CIRCLE,
+) -> Array:
+  """Gets the kernel with a given diameter and pixel size.
 
   Args:
-      diameter: A float that represents the diameter of the kernel, which acts
-        like a probe.
-      pixel_size: A tuple, list, or array that represents the physical size of
-        one pixel in the image.
+    diameter: A float that represents the diameter of the kernel, which acts
+      like a probe.
+    pixel_size: A tuple, list, or array that represents the physical size of one
+      pixel in the image.
+    kernel_shape: The kernel shape to use.
 
   Returns:
-      An array of unsigned integers 0 and 1. It represent the kernel for
-      morpological operations.
+    An array of unsigned integers 0 and 1 representing the kernel for
+    morpological operations.
   """
 
-  pixel_size = np.array(pixel_size)
-  se_shape = np.array(np.round(diameter / pixel_size), dtype=int)
+  pixel_size = np.asarray(pixel_size)
+  shape = np.array(np.round(diameter / pixel_size), dtype=int)
 
-  if se_shape[0] <= 2 and se_shape[1] <= 2:
-    return np.ones(se_shape, dtype=np.uint8)
+  if shape[0] <= 2 and shape[1] <= 2:
+    return np.ones(shape, dtype=np.uint8)
 
   rounded_size = np.round(diameter / pixel_size - 1) * pixel_size
 
-  x_tick = np.linspace(-rounded_size[0] / 2, rounded_size[0] / 2, se_shape[0])
-  y_tick = np.linspace(-rounded_size[1] / 2, rounded_size[1] / 2, se_shape[1])
+  if kernel_shape is KernelShape.CIRCLE:
+    x_tick = np.linspace(-rounded_size[0] / 2, rounded_size[0] / 2, shape[0])
+    y_tick = np.linspace(-rounded_size[1] / 2, rounded_size[1] / 2, shape[1])
+    x, y = np.meshgrid(x_tick, y_tick, sparse=True, indexing='ij')
+    return np.array(x**2 + y**2 <= diameter**2 / 4, dtype=np.uint8)
+  elif kernel_shape is KernelShape.RECTANGLE:
+    return np.ones(shape, dtype=np.uint8)
+  else:
+    raise ValueError(f'Unknown kernel shape: {kernel_shape.name}.')
 
-  x, y = np.meshgrid(
-      x_tick, y_tick, sparse=True, indexing='ij'
-  )  # grid over the entire design region
-  structuring_element = x**2 + y**2 <= diameter**2 / 4
 
-  return np.array(structuring_element, dtype=np.uint8)
+def _get_padding_for_kernel(kernel: Array) -> tuple[Padding, Padding]:
+  """Gets padding and unpadding width for a given kernel."""
+  shape = kernel.shape
+  pad_width = ((shape[0],) * 2, (shape[1],) * 2)
+  unpad_width = (
+      (
+          pad_width[0][0] + (shape[0] + 1) % 2,
+          pad_width[0][1] - (shape[0] + 1) % 2,
+      ),
+      (
+          pad_width[1][0] + (shape[1] + 1) % 2,
+          pad_width[1][1] - (shape[1] + 1) % 2,
+      ),
+  )
+  return pad_width, unpad_width
 
 
 def binary_open(
-    array: np.ndarray,
-    diameter: float,
-    pixel_size: PixelSize = (1.0, 1.0),
+    array: Array,
+    kernel: Array,
     pad_mode: PaddingMode = PaddingMode.EDGE,
-) -> np.ndarray:
+) -> Array:
   """Applies a binary morphological opening.
 
   Args:
-    array: A binarized 2d array that represents a binary image.
-    diameter: A float that represents the diameter of the kernel, which acts
-      like a probe.
-    pixel_size: A tuple, list, or array that represents the physical size of one
-      pixel in the image.
-    pad_mode: A string that represents the padding mode, which can be 'solid',
-      'void', or 'edge'.
+    array: A binarized 2D array that represents a binary image.
+    kernel: The kernel to use.
+    pad_mode: The padding mode.
 
   Returns:
-    A Boolean array that represents the outcome of morphological opening.
+    A boolean array that represents the outcome of morphological opening.
   """
-  kernel = _get_kernel(diameter, pixel_size)
-  array = _proper_pad(array, kernel, pad_mode)
+  pad_width, unpad_width = _get_padding_for_kernel(kernel)
+  array = _apply_padding(array, pad_width, pad_mode)
   opened = cv.morphologyEx(src=array, kernel=kernel, op=cv.MORPH_OPEN)
-  return _proper_unpad(opened, kernel).astype(bool)
+  return _remove_padding(opened, unpad_width).view(bool)
 
 
 def binary_close(
-    arr: np.ndarray,
-    diameter: float,
-    pixel_size: PixelSize = (1.0, 1.0),
+    arr: Array,
+    kernel: Array,
     pad_mode: PaddingMode = PaddingMode.EDGE,
-) -> np.ndarray:
+) -> Array:
   """Applies a binary morphological closing.
 
   Args:
-    arr: A binarized 2d array that represents a binary image.
-    diameter: A float that represents the diameter of the kernel, which acts
-      like a probe.
-    pixel_size: A tuple, list, or array that represents the physical size of one
-      pixel in the image.
-    pad_mode: A string that represents the padding mode, which can be 'solid',
-      'void', or 'edge'.
+    arr: A binarized 2D array that represents a binary image.
+    kernel: The kernel to use.
+    pad_mode: The padding mode.
 
   Returns:
-      A Boolean array that represents the outcome of morphological closing.
+    A boolean array that represents the outcome of morphological closing.
   """
-  kernel = _get_kernel(diameter, pixel_size)
-  arr = _proper_pad(arr, kernel, pad_mode)
+  pad_width, unpad_width = _get_padding_for_kernel(kernel)
+  arr = _apply_padding(arr, pad_width, pad_mode)
   closed = cv.morphologyEx(src=arr, kernel=kernel, op=cv.MORPH_CLOSE)
-  return _proper_unpad(closed, kernel).astype(bool)
+  return _remove_padding(closed, unpad_width).view(bool)
 
 
 def binary_erode(
-    array: np.ndarray,
-    diameter: float,
-    pixel_size: PixelSize = (1.0, 1.0),
+    array: Array,
+    kernel: Array,
     pad_mode: PaddingMode = PaddingMode.EDGE,
-) -> np.ndarray:
+) -> Array:
   """Applies a binary morphological erosion.
 
   Args:
-    array: A binarized 2d array that represents a binary image.
-    diameter: A float that represents the diameter of the kernel, which acts
-      like a probe.
-    pixel_size: A tuple, list, or array that represents the physical size of one
-      pixel in the image.
-    pad_mode: A string that represents the padding mode, which can be 'solid',
-      'void', or 'edge'.
+    array: A binarized 2D array that represents a binary image.
+    kernel: The kernel to use.
+    pad_mode: The padding mode.
 
   Returns:
-    A Boolean array that represents the outcome of morphological erosion.
+    A boolean array that represents the outcome of morphological erosion.
   """
-
-  kernel = _get_kernel(diameter, pixel_size)
-  array = _proper_pad(array, kernel, pad_mode)
+  pad_width, unpad_width = _get_padding_for_kernel(kernel)
+  array = _apply_padding(array, pad_width, pad_mode)
   eroded = cv.erode(array, kernel)
-
-  return _proper_unpad(eroded, kernel).astype(bool)
+  return _remove_padding(eroded, unpad_width).view(bool)
 
 
 def binary_dilate(
-    array: np.ndarray,
-    diameter: float,
-    pixel_size: PixelSize = (1.0, 1.0),
+    array: Array,
+    kernel: Array,
     pad_mode: PaddingMode = PaddingMode.EDGE,
-) -> np.ndarray:
+) -> Array:
   """Applies a binary morphological dilation.
 
   Args:
-    array: A binarized 2d array that represents a binary image.
-    diameter: A float that represents the diameter of the kernel, which acts
-      like a probe.
-    pixel_size: A tuple, list, or array that represents the physical size of one
-      pixel in the image.
-    pad_mode: A string that represents the padding mode, which can be 'solid',
-      'void', or 'edge'.
+    array: A binarized 2D array that represents a binary image.
+    kernel: The kernel to use.
+    pad_mode: The padding mode.
 
   Returns:
-    A Boolean array that represents the outcome of morphological dilation.
+    A boolean array that represents the outcome of morphological dilation.
   """
-
-  kernel = _get_kernel(diameter, pixel_size)
-  array = _proper_pad(array, kernel, pad_mode)
+  pad_width, unpad_width = _get_padding_for_kernel(kernel)
+  array = _apply_padding(array, pad_width, pad_mode)
   dilated = cv.dilate(array, kernel)
+  return _remove_padding(dilated, unpad_width).view(bool)
 
-  return _proper_unpad(dilated, kernel).astype(bool)
 
-
-def _proper_pad(
-    array: np.ndarray, kernel: np.ndarray, pad_mode: PaddingMode
-) -> np.ndarray:
-  """Pad the input array properly according to the size of the kernel.
-
-  Args:
-    array: A binarized 2d array that represents a binary image.
-    kernel: A 2d array that represents the kernel of morphological operations.
-    pad_mode: A string that represents the padding mode, which can be 'solid',
-      'void', or 'edge'.
-
-  Returns:
-    A padded array composed of unsigned integers 0 and 1.
-  """
-
-  ((top, bottom), (left, right)) = (
-      (kernel.shape[0],) * 2,
-      (kernel.shape[1],) * 2,
-  )
-
+def _apply_padding(
+    array: Array, pad_width: Padding, pad_mode: PaddingMode
+) -> Array:
+  """Applies padding to the input array."""
+  ((top, bottom), (left, right)) = pad_width
   if pad_mode is PaddingMode.EDGE:
     return cv.copyMakeBorder(
         array.view(np.uint8),
@@ -809,53 +868,29 @@ def _proper_pad(
     raise ValueError(f'Unknown padding mode: {pad_mode.name}.')
 
 
-def _proper_unpad(array: np.ndarray, kernel: np.ndarray) -> np.ndarray:
-  """Removes padding according to the size of the kernel.
-
-  The code is copied from Martin F. Schubert's code at
-  https://github.com/mfschubert/topology/blob/main/metrics.py
-
-  Args:
-    array: A 2d array that has extra padding.
-    kernel: A 2d array that represents the kernel of morphological operations.
-
-  Returns:
-    A 2d array without padding.
-  """
-
-  unpad_width = (
-      (
-          kernel.shape[0] + (kernel.shape[0] + 1) % 2,
-          kernel.shape[0] - (kernel.shape[0] + 1) % 2,
-      ),
-      (
-          kernel.shape[1] + (kernel.shape[1] + 1) % 2,
-          kernel.shape[1] - (kernel.shape[1] + 1) % 2,
-      ),
-  )
-
+def _remove_padding(array: Array, pad_width: Padding) -> Array:
+  """Removes padding from the input array."""
   slices = tuple(
-      [
-          slice(pad_lo, dim - pad_hi)
-          for (pad_lo, pad_hi), dim in zip(unpad_width, array.shape)
-      ]
+      slice(pad_lo, dim - pad_hi)
+      for (pad_lo, pad_hi), dim in zip(pad_width, array.shape)
   )
   return array[slices]
 
 
-def _trim(
-    array: np.ndarray, margin_size: MarginSize, pixel_size: PixelSize
-) -> np.ndarray:
+def _trim_margins(
+    array: Array, margin_size: MarginSize, pixel_size: PixelSize
+) -> Array:
   """Trims margins from an array.
 
   Args:
-    array: The image as a 1d or 2d array.
+    array: The 1D or 2D binarized image array.
     margin_size: The physical dimensions of the image margins. If specified,
-      this subregion is excluded from the result. No default.
-    pixel_size: The physical size of one pixel in the image. No default.
+      this subregion is excluded from the length scale measurement. Default is
+      no margins.
+    pixel_size: The physical size of one pixel in the image.
 
   Returns:
-    A subarray of the input array.
+    The input array with the sepecified margins trimmed.
   """
 
   array = np.squeeze(array)

--- a/imageruler/imageruler.py
+++ b/imageruler/imageruler.py
@@ -729,7 +729,7 @@ def get_kernel(
     raise ValueError(f'Unknown kernel shape: {kernel_shape.name}.')
 
 
-def _get_padding_for_kernel(kernel: Array) -> tuple[Padding, Padding]:
+def _get_padding_for_kernel(kernel: Array) -> Tuple[Padding, Padding]:
   """Gets padding and unpadding width for a given kernel."""
   shape = kernel.shape
   pad_width = ((shape[0],) * 2, (shape[1],) * 2)

--- a/imageruler/test_imageruler.py
+++ b/imageruler/test_imageruler.py
@@ -30,10 +30,11 @@ class TestDuality(unittest.TestCase):
     Returns:
         A Boolean indicating whether duality is satisfied or not.
     """
-    erosion_of_negation = imageruler.binary_erode(~weights, diam)
-    negation_of_dilation = ~imageruler.binary_dilate(weights, diam)
-    dilation_of_negation = imageruler.binary_dilate(~weights, diam)
-    negation_of_erosion = ~imageruler.binary_erode(weights, diam)
+    kernel = imageruler.get_kernel(diam)
+    erosion_of_negation = imageruler.binary_erode(~weights, kernel)
+    negation_of_dilation = ~imageruler.binary_dilate(weights, kernel)
+    dilation_of_negation = imageruler.binary_dilate(~weights, kernel)
+    negation_of_erosion = ~imageruler.binary_erode(weights, kernel)
     return (erosion_of_negation == negation_of_dilation).all() and (
         negation_of_erosion == dilation_of_negation
     ).all()
@@ -50,10 +51,11 @@ class TestDuality(unittest.TestCase):
     Returns:
         A Boolean indicating whether duality is satisfied or not.
     """
-    opening_of_negation = imageruler.binary_open(~weights, diam)
-    negation_of_closing = ~imageruler.binary_close(weights, diam)
-    closing_of_negation = imageruler.binary_close(~weights, diam)
-    negation_of_opening = ~imageruler.binary_open(weights, diam)
+    kernel = imageruler.get_kernel(diam)
+    opening_of_negation = imageruler.binary_open(~weights, kernel)
+    negation_of_closing = ~imageruler.binary_close(weights, kernel)
+    closing_of_negation = imageruler.binary_close(~weights, kernel)
+    negation_of_opening = ~imageruler.binary_open(weights, kernel)
     return (opening_of_negation == negation_of_closing).all() and (
         closing_of_negation == negation_of_opening
     ).all()

--- a/notebooks/examples.ipynb
+++ b/notebooks/examples.ipynb
@@ -397,8 +397,8 @@
     }
    ],
    "source": [
-    "solid_mls_void = imageruler.minimum_length_solid(image, phys_size, pad_mode='void')\n",
-    "solid_mls_edge = imageruler.minimum_length_solid(image, phys_size, pad_mode='edge')\n",
+    "solid_mls_void = imageruler.minimum_length_solid(image, phys_size, pad_mode=imageruler.PaddingMode.VOID)\n",
+    "solid_mls_edge = imageruler.minimum_length_solid(image, phys_size, pad_mode=imageruler.PaddingMode.EDGE)\n",
     "print(\"Estimated minimum length scale of the solid region: \", solid_mls_void, \"(void padding), \", solid_mls_edge, \"(edge-mode padding)\")"
    ]
   },


### PR DESCRIPTION
This PR further cleans up the codebase and adds an option for selecting the kernel shape.

- Add `KernelShape` enum with `CIRCLE` and `RECTANGLE` members for selecting the shape of the kernel used in the morphological operations; all functions default to `CIRCLE` to preserve the existing behavior (addressing #4)
- Define and use an explicit 3x3 "plus kernel" for dealing with the boundary pixels (adopting from @mfschubert's approach), rather than relying on the circular brush kernel function to implicitly generate such a kernel
- Refactor and reorganize lower level morphological functions to take kernels, rather than scalar `diameter` values
- Clean up all doc strings and better clarify some default behaviors
- Add `Direction` enum to replace strings which were used to define the boundary union
- Rename some internal functions for improved clarity
- Update test to use the updates morphological function APIs
- Fix padding mode in notebook to use new enums from #19 instead of strings